### PR TITLE
Javet v0.8.10

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Maven
     <dependency>
         <groupId>com.caoccao.javet</groupId>
         <artifactId>javet</artifactId>
-        <version>0.8.9</version>
+        <version>0.8.10</version>
     </dependency>
 
 Gradle Kotlin DSL
@@ -48,14 +48,14 @@ Gradle Kotlin DSL
 
 .. code-block:: kotlin
 
-    implementation("com.caoccao.javet:javet:0.8.9")
+    implementation("com.caoccao.javet:javet:0.8.10")
 
 Gradle Groovy DSL
 ^^^^^^^^^^^^^^^^^
 
 .. code-block:: groovy
 
-    implementation 'com.caoccao.javet:javet:0.8.9'
+    implementation 'com.caoccao.javet:javet:0.8.10'
 
 Hello Javet
 -----------

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ repositories {
 }
 
 group = "com.caoccao.javet"
-version = "0.8.9"
+version = "0.8.10"
 
 repositories {
     mavenCentral()

--- a/cpp/build.cmd
+++ b/cpp/build.cmd
@@ -1,7 +1,7 @@
 @echo off
 REM Usage for V8: build -DV8_DIR=C:\v8 
 REM Usage for Node: build -DNODE_DIR=C:\node 
-SET JAVET_VERSION=0.8.9
+SET JAVET_VERSION=0.8.10
 rd /s/q build
 mkdir build
 cd build

--- a/cpp/build.sh
+++ b/cpp/build.sh
@@ -2,7 +2,7 @@
 
 # Usage for V8: build -DV8_DIR=~/v8
 # Usage for Node: build -DNODE_DIR=~/node
-JAVET_VERSION=0.8.9
+JAVET_VERSION=0.8.10
 rm -rf build
 mkdir build
 cd build

--- a/cpp/jni/javet_resource_node.rc
+++ b/cpp/jni/javet_resource_node.rc
@@ -61,8 +61,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,8,9,0
- PRODUCTVERSION 0,8,9,0
+ FILEVERSION 0,8,10,0
+ PRODUCTVERSION 0,8,10,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -79,12 +79,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "caoccao.com"
             VALUE "FileDescription", "caoccao.com"
-            VALUE "FileVersion", "0.8.9.0"
-            VALUE "InternalName", "libjavet-node-windows-x86_64.v.0.8.9.dll"
+            VALUE "FileVersion", "0.8.10.0"
+            VALUE "InternalName", "libjavet-node-windows-x86_64.v.0.8.10.dll"
             VALUE "LegalCopyright", "Copyright (C) 2021"
-            VALUE "OriginalFilename", "libjavet-node-windows-x86_64.v.0.8.9.dll"
+            VALUE "OriginalFilename", "libjavet-node-windows-x86_64.v.0.8.10.dll"
             VALUE "ProductName", "Javet Windows"
-            VALUE "ProductVersion", "0.8.9.0"
+            VALUE "ProductVersion", "0.8.10.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/cpp/jni/javet_resource_v8.rc
+++ b/cpp/jni/javet_resource_v8.rc
@@ -61,8 +61,8 @@ LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,8,9,0
- PRODUCTVERSION 0,8,9,0
+ FILEVERSION 0,8,10,0
+ PRODUCTVERSION 0,8,10,0
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -79,12 +79,12 @@ BEGIN
         BEGIN
             VALUE "CompanyName", "caoccao.com"
             VALUE "FileDescription", "caoccao.com"
-            VALUE "FileVersion", "0.8.9.0"
-            VALUE "InternalName", "libjavet-v8-windows-x86_64.v.0.8.9.dll"
+            VALUE "FileVersion", "0.8.10.0"
+            VALUE "InternalName", "libjavet-v8-windows-x86_64.v.0.8.10.dll"
             VALUE "LegalCopyright", "Copyright (C) 2021"
-            VALUE "OriginalFilename", "libjavet-v8-windows-x86_64.v.0.8.9.dll"
+            VALUE "OriginalFilename", "libjavet-v8-windows-x86_64.v.0.8.10.dll"
             VALUE "ProductName", "Javet Windows"
-            VALUE "ProductVersion", "0.8.9.0"
+            VALUE "ProductVersion", "0.8.10.0"
         END
     END
     BLOCK "VarFileInfo"

--- a/docs/reference/error_codes.rst
+++ b/docs/reference/error_codes.rst
@@ -51,3 +51,10 @@ Code Type        Name                                   Format
 
 
 [`Home <../../README.rst>`_] [`Javet Reference <index.rst>`_]
+====================================================================================================================================
+
+
+.. Error Codes End
+
+
+[`Home <../../README.rst>`_] [`Javet Reference <index.rst>`_]

--- a/docs/reference/v8_function.rst
+++ b/docs/reference/v8_function.rst
@@ -29,26 +29,20 @@ Function Interception
 
 Functions can be intercepted via Javet API. This is equivalent to the capability provided by Node.js. However, there is still a key difference between user defined functions and function interception: local scoped context is visible to user defined function, but invisible to function interceptor. Why? That's a long story related to how closure is implemented in V8 which is not the goal in this section. If local scoped context has to be required, please consider changing the function on the fly which is documented in next section.
 
-``com.caoccao.javet.values.reference.IV8ValueObject`` exposes a set of ``bindFunction`` and ``bindFunctions`` that allow caller to register function interceptors in automatic or manual ways.
+``com.caoccao.javet.values.reference.IV8ValueObject`` exposes a set of ``bindFunction()`` that allow caller to register function interceptors in automatic or manual ways.
 
 Automatic Registration
 ----------------------
 
-bind, bindFunctions, bindProperties
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+``bind()``
+^^^^^^^^^^
 
-``bindFunctions`` scans the input callback receiver for functions decorated by ``@V8Function``. It allows registering many functions in one call.
-
-``bindProperties`` scans the input callback receiver for functions decorated by ``@V8Property``. It allows registering many getters and setters in one call.
-
-``bind`` calls ``bindFunctions`` and ``bindProperties`` internally, in case a complete registration is needed.
+``bind()`` scans the input callback receiver for functions decorated by ``@V8Function`` and ``@V8Property``. It allows registering many getters / setters and functions in one call.
 
 .. code-block:: java
 
+    List<JavetCallbackContext> bind(Object functionCallbackReceiver);
     List<JavetCallbackContext> bind(Object functionCallbackReceiver, boolean thisObjectRequired);
-    List<JavetCallbackContext> bindFunctions(Object functionCallbackReceiver);
-    List<JavetCallbackContext> bindFunctions(Object functionCallbackReceiver, boolean thisObjectRequired);
-    List<JavetCallbackContext> bindProperties(Object propertyCallbackReceiver);
 
 How about Object Type Conversion?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -136,7 +130,7 @@ The second step is to call the functions or properties.
     try (V8ValueObject v8ValueObject = v8Runtime.createV8ValueObject()) {
         v8Runtime.getGlobalObject().set("a", v8ValueObject);
         AnnotationBasedCallbackReceiver annotationBasedCallbackReceiver = new AnnotationBasedCallbackReceiver();
-        v8ValueObject.bindFunctions(annotationBasedCallbackReceiver);
+        v8ValueObject.bind(annotationBasedCallbackReceiver);
         assertEquals("test", v8Runtime.getExecutor("a.echo('test')").executeString());
         assertEquals(3, v8Runtime.getExecutor("a.add(1, 2)").executeInteger());
         try (V8ValueArray v8ValueArray = v8Runtime.getExecutor(

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -2,6 +2,12 @@
 Release Notes
 =============
 
+0.8.10
+------
+
+* Renamed ``IJavetConsumer`` to ``IJavetUniConsumer``
+* Added ``IJavetUniIndexedConsumer`` and ``IJavetBiIndexedConsumer``
+
 0.8.9
 -----
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -7,6 +7,7 @@ Release Notes
 
 * Renamed ``IJavetConsumer`` to ``IJavetUniConsumer``
 * Added ``IJavetUniIndexedConsumer`` and ``IJavetBiIndexedConsumer``
+* Fixed a bug in ``V8FunctionCallback`` on varargs
 
 0.8.9
 -----

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -9,6 +9,7 @@ Release Notes
 * Added ``IJavetUniIndexedConsumer`` and ``IJavetBiIndexedConsumer``
 * Fixed a bug in ``V8FunctionCallback`` on varargs
 * Deprecated ``bindFunctions()`` and ``bindProperties()``
+* Added ``@CheckReturnValue`` to warn ignored return value
 
 0.8.9
 -----

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -8,6 +8,7 @@ Release Notes
 * Renamed ``IJavetConsumer`` to ``IJavetUniConsumer``
 * Added ``IJavetUniIndexedConsumer`` and ``IJavetBiIndexedConsumer``
 * Fixed a bug in ``V8FunctionCallback`` on varargs
+* Deprecated ``bindFunctions()`` and ``bindProperties()``
 
 0.8.9
 -----

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -8,10 +8,10 @@ Basic
 * `Installation <installation.rst>`_
 * `Hello Javet <hello_javet.rst>`_
 * `Engine Pool <engine_pool.rst>`_
+* `Interception <interception.rst>`_
 * `Javet Shell <javet_shell.rst>`_
 * `Node.js Mode and V8 Mode <node_js_mode_and_v8_mode.rst>`_
 * `Spring Integration <spring_integration.rst>`_
-
 * `Polyfill <polyfill.rst>`_
 
 Advanced

--- a/docs/tutorial/installation.rst
+++ b/docs/tutorial/installation.rst
@@ -13,7 +13,7 @@ Maven
     <dependency>
         <groupId>com.caoccao.javet</groupId>
         <artifactId>javet</artifactId>
-        <version>0.8.9</version>
+        <version>0.8.10</version>
     </dependency>
 
 Gradle Kotlin DSL
@@ -21,14 +21,14 @@ Gradle Kotlin DSL
 
 .. code-block:: kotlin
 
-    implementation("com.caoccao.javet:javet:0.8.9")
+    implementation("com.caoccao.javet:javet:0.8.10")
 
 Gradle Groovy DSL
 -----------------
 
 .. code-block:: groovy
 
-    implementation 'com.caoccao.javet:javet:0.8.9'
+    implementation 'com.caoccao.javet:javet:0.8.10'
 
 OS Compatibility
 ================

--- a/docs/tutorial/interception.rst
+++ b/docs/tutorial/interception.rst
@@ -1,0 +1,112 @@
+============
+Interception
+============
+
+Javet provides ``@V8Property`` and ``@V8Function`` which allow Java applications to intercept JavaScript properties and functions in an automatic way as following.
+
+* Decorate a Java class with ``@V8Property`` or ``@V8Function``.
+* Bind an instance of that Java class to a V8 value object.
+* Call the properties or functions of that V8 value object in JavaScript.
+* The calls are intercepted by that instance of the Java class.
+
+Sample
+======
+
+``@V8Property`` and ``@V8Function``
+-----------------------------------
+
+``@V8Property`` is for registering getters and setters. Javet is good at guessing the property name, e.g. getName => name, setValue => value.
+
+``@V8Function`` is for registering functions. By default, the Java function name is identical to the JavaScript function name, e.g. increaseAndGet => increaseAndGet, add => add.
+
+If the default name is not suitable, please tell Javet which one to bind via ``@V8Property(name = "...")`` and ``@V8Function(name = "...")``.
+
+.. code-block:: java
+
+    public class TestInterception {
+        private String name;
+        private int value;
+
+        @V8Property
+        public String getName() {
+            return name;
+        }
+    
+        @V8Property
+        public void setName(String name) {
+            this.name = name;
+        }
+    
+        @V8Property
+        public int getValue() {
+            return value;
+        }
+    
+        @V8Property
+        public void setValue(int value) {
+            this.value = value;
+        }
+    
+        @V8Function
+        public int increaseAndGet() {
+            return ++value;
+        }
+    
+        @V8Function
+        public int add(int delta) {
+            value += delta;
+            return value;
+        }
+    }
+
+Test
+----
+
+.. code-block:: java
+
+    // Step 1: Create a V8 runtime from V8 host in try-with-resource.
+    try (V8Runtime v8Runtime = V8Host.getV8Instance().createV8Runtime()) {
+        // Step 2: Register console.
+        JavetStandardConsoleInterceptor javetStandardConsoleInterceptor = new JavetStandardConsoleInterceptor(v8Runtime);
+        javetStandardConsoleInterceptor.register(v8Runtime.getGlobalObject());
+        // Step 3: Create an interceptor.
+        TestInterception testInterceptor = new TestInterception();
+        // Step 4: Bind the interceptor to a variable.
+        try (V8ValueObject v8ValueObject = v8Runtime.createV8ValueObject()) {
+            v8Runtime.getGlobalObject().set("a", v8ValueObject);
+            v8ValueObject.bind(testInterceptor);
+        }
+
+        // Test property name
+        v8Runtime.getExecutor("console.log(`a.name is initially ${a.name}.`);").executeVoid(); // null
+        // a.name setter => setName(String name)
+        v8Runtime.getExecutor("a.name = 'Javet';").executeVoid();
+        // name is changed
+        System.out.println("Interceptor name is " + testInterceptor.getName() + "."); // Javet
+        // a.name getter => getName()
+        v8Runtime.getExecutor("console.log(`a.name is now ${a.name}.`);").executeVoid(); // Javet
+
+        // Test property value
+        v8Runtime.getExecutor("console.log(`a.value is initially ${a.value}.`);").executeVoid(); // 0
+        // a.value setter => setValue(String value)
+        v8Runtime.getExecutor("a.value = 123;").executeVoid();
+        // value is changed
+        System.out.println("Interceptor value is " + testInterceptor.getValue() + "."); // 123
+        // a.value getter => getValue()
+        v8Runtime.getExecutor("console.log(`a.value is now ${a.value}.`);").executeVoid(); // 123
+
+        // Test functions
+        v8Runtime.getExecutor("console.log(`a.increaseAndGet() is ${a.increaseAndGet()}.`);").executeVoid(); // 124
+        v8Runtime.getExecutor("console.log(`a.add(76) is ${a.add(76)}.`);").executeVoid(); // 200
+
+        // Step 5: Delete the interceptor.
+        v8Runtime.getGlobalObject().delete("a");
+        // Step 6: Unregister console.
+        javetStandardConsoleInterceptor.unregister(v8Runtime.getGlobalObject());
+        // Step 7: Notify V8 to perform GC. (Optional)
+        v8Runtime.lowMemoryNotification();
+    }
+
+Please refer to `source code <../../src/test/java/com/caoccao/javet/tutorial/TestInterception.java>`_ for more detail.
+
+[`Home <../../README.rst>`_] [`Javet Tutorial <index.rst>`_]

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.caoccao.javet</groupId>
     <artifactId>javet</artifactId>
-    <version>0.8.9</version>
+    <version>0.8.10</version>
     <name>javet</name>
     <description>Javet is Java + V8 (JAVa + V + EighT). It is a way of embedding V8 in Java.</description>
     <url>https://github.com/caoccao/Javet</url>
@@ -28,7 +28,7 @@
         <connection>scm:git:git://github.com/caoccao/Javet.git</connection>
         <developerConnection>scm:git:git@github.com:caoccao/caoccao.git</developerConnection>
         <url>https://github.com/caoccao/Javet</url>
-        <tag>javet-0.8.9</tag>
+        <tag>javet-0.8.10</tag>
     </scm>
 
     <properties>

--- a/scripts/node/javet-rebuild/rebuild.cmd
+++ b/scripts/node/javet-rebuild/rebuild.cmd
@@ -1,5 +1,5 @@
 @echo off
-SET NODE_LIB_FILE="..\..\..\..\..\..\build\libs\libjavet-node-windows-x86_64.v.0.8.9.lib"
+SET NODE_LIB_FILE="..\..\..\..\..\..\build\libs\libjavet-node-windows-x86_64.v.0.8.10.lib"
 cd %NODE_MODULE_ROOT%
 call node-gyp clean
 call node-gyp configure --module_name=%NODE_MODULE_NAME% --module_path=%NODE_MODULE_PATH% --node_lib_file=%NODE_LIB_FILE%

--- a/scripts/node/javet-rebuild/rebuild.sh
+++ b/scripts/node/javet-rebuild/rebuild.sh
@@ -1,1 +1,1 @@
-patchelf --add-needed libjavet-node-linux-x86_64.v.0.8.9.so ${NODE_MODULE_FILE}
+patchelf --add-needed libjavet-node-linux-x86_64.v.0.8.10.so ${NODE_MODULE_FILE}

--- a/scripts/python/change_javet_version.py
+++ b/scripts/python/change_javet_version.py
@@ -109,7 +109,7 @@ class ChangeJavetVersion(object):
       logging.info('  Updated.')
 
 def main():
-  change_javet_version = ChangeJavetVersion('0.8.9')
+  change_javet_version = ChangeJavetVersion('0.8.10')
   change_javet_version.update()
   return 0
 

--- a/src/main/java/com/caoccao/javet/annotations/CheckReturnValue.java
+++ b/src/main/java/com/caoccao/javet/annotations/CheckReturnValue.java
@@ -1,0 +1,9 @@
+package com.caoccao.javet.annotations;
+
+import java.lang.annotation.*;
+
+@Documented
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE, ElementType.PACKAGE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckReturnValue {
+}

--- a/src/main/java/com/caoccao/javet/annotations/NodeModule.java
+++ b/src/main/java/com/caoccao/javet/annotations/NodeModule.java
@@ -17,11 +17,9 @@
 
 package com.caoccao.javet.annotations;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
+@Documented
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface NodeModule {

--- a/src/main/java/com/caoccao/javet/annotations/V8Function.java
+++ b/src/main/java/com/caoccao/javet/annotations/V8Function.java
@@ -17,11 +17,9 @@
 
 package com.caoccao.javet.annotations;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
+@Documented
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface V8Function {

--- a/src/main/java/com/caoccao/javet/annotations/V8Property.java
+++ b/src/main/java/com/caoccao/javet/annotations/V8Property.java
@@ -17,11 +17,9 @@
 
 package com.caoccao.javet.annotations;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
+@Documented
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface V8Property {

--- a/src/main/java/com/caoccao/javet/annotations/V8RuntimeSetter.java
+++ b/src/main/java/com/caoccao/javet/annotations/V8RuntimeSetter.java
@@ -17,11 +17,9 @@
 
 package com.caoccao.javet.annotations;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
+@Documented
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface V8RuntimeSetter {

--- a/src/main/java/com/caoccao/javet/entities/JavetEntityMap.java
+++ b/src/main/java/com/caoccao/javet/entities/JavetEntityMap.java
@@ -36,6 +36,7 @@ public class JavetEntityMap extends HashMap<String, Object> {
         super(m);
     }
 
+    @SuppressWarnings("MethodDoesntCallSuperMethod")
     @Override
     public Object clone() {
         return new JavetEntityMap(this);

--- a/src/main/java/com/caoccao/javet/enums/JSFunctionType.java
+++ b/src/main/java/com/caoccao/javet/enums/JSFunctionType.java
@@ -6,8 +6,8 @@ public enum JSFunctionType {
     UserDefined(2, "UserDefined"),
     Unknown(3, "Unknown");
 
-    private int id;
-    private String name;
+    private final int id;
+    private final String name;
 
     JSFunctionType(int id, String name) {
         this.id = id;

--- a/src/main/java/com/caoccao/javet/enums/JSRuntimeType.java
+++ b/src/main/java/com/caoccao/javet/enums/JSRuntimeType.java
@@ -21,8 +21,8 @@ public enum JSRuntimeType {
     Node("node", "8.4.371.19-node.18"),
     V8("v8", "9.0.257");
 
-    private String name;
-    private String version;
+    private final String name;
+    private final String version;
 
     JSRuntimeType(String name, String version) {
         this.name = name;

--- a/src/main/java/com/caoccao/javet/enums/JSScopeType.java
+++ b/src/main/java/com/caoccao/javet/enums/JSScopeType.java
@@ -11,8 +11,8 @@ public enum JSScopeType {
     With(7, "With"),
     Unknown(8, "Unknown");
 
-    private int id;
-    private String name;
+    private final int id;
+    private final String name;
 
     JSScopeType(int id, String name) {
         this.id = id;

--- a/src/main/java/com/caoccao/javet/enums/JavetPromiseRejectEvent.java
+++ b/src/main/java/com/caoccao/javet/enums/JavetPromiseRejectEvent.java
@@ -29,8 +29,8 @@ public enum JavetPromiseRejectEvent {
             PromiseResolveAfterResolved,
             PromiseRejectAfterResolved};
 
-    private int code;
-    private String name;
+    private final int code;
+    private final String name;
 
     JavetPromiseRejectEvent(int code, String name) {
         this.code = code;

--- a/src/main/java/com/caoccao/javet/enums/V8ValueReferenceType.java
+++ b/src/main/java/com/caoccao/javet/enums/V8ValueReferenceType.java
@@ -57,8 +57,8 @@ public enum V8ValueReferenceType {
         }
     }
 
-    private int id;
-    private String name;
+    private final int id;
+    private final String name;
 
     V8ValueReferenceType(int id, String name) {
         this.id = id;

--- a/src/main/java/com/caoccao/javet/interception/logging/BaseJavetConsoleInterceptor.java
+++ b/src/main/java/com/caoccao/javet/interception/logging/BaseJavetConsoleInterceptor.java
@@ -97,6 +97,14 @@ public abstract class BaseJavetConsoleInterceptor extends BaseJavetInterceptor {
 
     @Override
     public boolean unregister(IV8ValueObject iV8ValueObject) throws JavetException {
+        try (V8ValueObject console = iV8ValueObject.get(PROPERTY_CONSOLE)) {
+            console.delete(JS_FUNCTION_DEBUG);
+            console.delete(JS_FUNCTION_ERROR);
+            console.delete(JS_FUNCTION_INFO);
+            console.delete(JS_FUNCTION_LOG);
+            console.delete(JS_FUNCTION_TRACE);
+            console.delete(JS_FUNCTION_WARN);
+        }
         return iV8ValueObject.delete(PROPERTY_CONSOLE);
     }
 }

--- a/src/main/java/com/caoccao/javet/interfaces/IJavetBiIndexedConsumer.java
+++ b/src/main/java/com/caoccao/javet/interfaces/IJavetBiIndexedConsumer.java
@@ -1,0 +1,25 @@
+/*
+ *   Copyright (c) 2021. caoccao.com Sam Cao
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.caoccao.javet.interfaces;
+
+import com.caoccao.javet.exceptions.JavetException;
+import com.caoccao.javet.values.V8Value;
+
+public interface IJavetBiIndexedConsumer<T1 extends V8Value, T2 extends V8Value, E extends Throwable> {
+    void accept(int index, T1 value1, T2 value2) throws JavetException, E;
+}

--- a/src/main/java/com/caoccao/javet/interfaces/IJavetUniConsumer.java
+++ b/src/main/java/com/caoccao/javet/interfaces/IJavetUniConsumer.java
@@ -1,0 +1,25 @@
+/*
+ *   Copyright (c) 2021. caoccao.com Sam Cao
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.caoccao.javet.interfaces;
+
+import com.caoccao.javet.exceptions.JavetException;
+import com.caoccao.javet.values.V8Value;
+
+public interface IJavetUniConsumer<T extends V8Value, E extends Throwable> {
+    void accept(T value) throws JavetException, E;
+}

--- a/src/main/java/com/caoccao/javet/interfaces/IJavetUniIndexedConsumer.java
+++ b/src/main/java/com/caoccao/javet/interfaces/IJavetUniIndexedConsumer.java
@@ -20,6 +20,6 @@ package com.caoccao.javet.interfaces;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.V8Value;
 
-public interface IJavetConsumer<T extends V8Value, E extends Throwable> {
-    void accept(T value) throws JavetException, E;
+public interface IJavetUniIndexedConsumer<T extends V8Value, E extends Throwable> {
+    void accept(int index, T value) throws JavetException, E;
 }

--- a/src/main/java/com/caoccao/javet/interop/IV8Cloneable.java
+++ b/src/main/java/com/caoccao/javet/interop/IV8Cloneable.java
@@ -17,10 +17,11 @@
 
 package com.caoccao.javet.interop;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.V8Value;
 
-@SuppressWarnings("unchecked")
 public interface IV8Cloneable {
+    @CheckReturnValue
     <T extends V8Value> T toClone() throws JavetException;
 }

--- a/src/main/java/com/caoccao/javet/interop/IV8Convertible.java
+++ b/src/main/java/com/caoccao/javet/interop/IV8Convertible.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.interop;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.utils.JavetResourceUtils;
 import com.caoccao.javet.values.V8Value;
@@ -24,7 +25,6 @@ import com.caoccao.javet.values.V8Value;
 /**
  * The interface V8 convertible.
  */
-@SuppressWarnings("unchecked")
 public interface IV8Convertible {
     /**
      * Convert from V8 value to object.
@@ -36,7 +36,7 @@ public interface IV8Convertible {
      * @return the object
      * @throws JavetException the javet exception
      */
-    <T extends Object, V extends V8Value> T toObject(V v8Value) throws JavetException;
+    <T, V extends V8Value> T toObject(V v8Value) throws JavetException;
 
     /**
      * Convert from V8 value to object.
@@ -49,7 +49,7 @@ public interface IV8Convertible {
      * @return the t
      * @throws JavetException the javet exception
      */
-    default <T extends Object, V extends V8Value> T toObject(V v8Value, boolean autoClose) throws JavetException {
+    default <T, V extends V8Value> T toObject(V v8Value, boolean autoClose) throws JavetException {
         if (autoClose) {
             try {
                 return toObject(v8Value);
@@ -70,5 +70,6 @@ public interface IV8Convertible {
      * @return the V8 value
      * @throws JavetException the javet exception
      */
-    <T extends Object, V extends V8Value> V toV8Value(T object) throws JavetException;
+    @CheckReturnValue
+    <T, V extends V8Value> V toV8Value(T object) throws JavetException;
 }

--- a/src/main/java/com/caoccao/javet/interop/IV8Creatable.java
+++ b/src/main/java/com/caoccao/javet/interop/IV8Creatable.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.interop;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.utils.JavetCallbackContext;
@@ -26,32 +27,40 @@ import com.caoccao.javet.values.reference.*;
 import java.time.ZonedDateTime;
 
 public interface IV8Creatable {
+    @CheckReturnValue
     V8ValueArray createV8ValueArray() throws JavetException;
 
+    @CheckReturnValue
     V8ValueArrayBuffer createV8ValueArrayBuffer(int length) throws JavetException;
 
     V8ValueBoolean createV8ValueBoolean(boolean booleanValue) throws JavetException;
 
+    @CheckReturnValue
     V8ValueDataView createV8ValueDataView(V8ValueArrayBuffer v8ValueArrayBuffer) throws JavetException;
 
     V8ValueDouble createV8ValueDouble(double doubleValue) throws JavetException;
 
+    @CheckReturnValue
     V8ValueFunction createV8ValueFunction(JavetCallbackContext javetCallbackContext) throws JavetException;
 
     V8ValueInteger createV8ValueInteger(int integerValue) throws JavetException;
 
     V8ValueLong createV8ValueLong(long longValue) throws JavetException;
 
+    @CheckReturnValue
     V8ValueMap createV8ValueMap() throws JavetException;
 
     V8ValueNull createV8ValueNull();
 
+    @CheckReturnValue
     V8ValueObject createV8ValueObject() throws JavetException;
 
+    @CheckReturnValue
     V8ValueSet createV8ValueSet() throws JavetException;
 
     V8ValueString createV8ValueString(String str) throws JavetException;
 
+    @CheckReturnValue
     V8ValueTypedArray createV8ValueTypedArray(V8ValueReferenceType type, int length) throws JavetException;
 
     V8ValueUndefined createV8ValueUndefined();

--- a/src/main/java/com/caoccao/javet/interop/IV8Executable.java
+++ b/src/main/java/com/caoccao/javet/interop/IV8Executable.java
@@ -17,37 +17,89 @@
 
 package com.caoccao.javet.interop;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.V8Value;
 import com.caoccao.javet.values.primitive.V8ValuePrimitive;
 
 import java.time.ZonedDateTime;
 
+/**
+ * The interface V8 executable.
+ */
 @SuppressWarnings("unchecked")
 public interface IV8Executable extends IV8Convertible {
+    /**
+     * Execute t.
+     *
+     * @param <T> the type parameter
+     * @return the t
+     * @throws JavetException the javet exception
+     */
+    @CheckReturnValue
     default <T extends V8Value> T execute() throws JavetException {
         return execute(true);
     }
 
+    /**
+     * Execute t.
+     *
+     * @param <T>            the type parameter
+     * @param resultRequired the result required
+     * @return the t
+     * @throws JavetException the javet exception
+     */
+    @CheckReturnValue
     <T extends V8Value> T execute(boolean resultRequired) throws JavetException;
 
+    /**
+     * Execute boolean boolean.
+     *
+     * @return the boolean
+     * @throws JavetException the javet exception
+     */
     default Boolean executeBoolean() throws JavetException {
         return executePrimitive();
     }
 
+    /**
+     * Execute double double.
+     *
+     * @return the double
+     * @throws JavetException the javet exception
+     */
     default Double executeDouble() throws JavetException {
         return executePrimitive();
     }
 
+    /**
+     * Execute integer integer.
+     *
+     * @return the integer
+     * @throws JavetException the javet exception
+     */
     default Integer executeInteger() throws JavetException {
         return executePrimitive();
     }
 
+    /**
+     * Execute long long.
+     *
+     * @return the long
+     * @throws JavetException the javet exception
+     */
     default Long executeLong() throws JavetException {
         return executePrimitive();
     }
 
-    default <T extends Object> T executeObject() throws JavetException {
+    /**
+     * Execute object t.
+     *
+     * @param <T> the type parameter
+     * @return the t
+     * @throws JavetException the javet exception
+     */
+    default <T> T executeObject() throws JavetException {
         try (V8Value v8Value = execute()) {
             return toObject(v8Value);
         } catch (JavetException e) {
@@ -57,25 +109,50 @@ public interface IV8Executable extends IV8Convertible {
         }
     }
 
-    default <R extends Object, T extends V8ValuePrimitive<R>> R executePrimitive() throws JavetException {
+    /**
+     * Execute primitive r.
+     *
+     * @param <R> the type parameter
+     * @param <T> the type parameter
+     * @return the r
+     * @throws JavetException the javet exception
+     */
+    default <R, T extends V8ValuePrimitive<R>> R executePrimitive() throws JavetException {
         try (V8Value v8Value = execute()) {
-            try {
-                return ((T) v8Value).getValue();
-            } catch (Throwable t) {
-            }
+            return ((T) v8Value).getValue();
+        } catch (JavetException e) {
+            throw e;
+        } catch (Throwable ignored) {
         }
         return null;
     }
 
-    default String executeString()
-            throws JavetException {
+    /**
+     * Execute string string.
+     *
+     * @return the string
+     * @throws JavetException the javet exception
+     */
+    default String executeString() throws JavetException {
         return executePrimitive();
     }
 
+    /**
+     * Execute void.
+     *
+     * @throws JavetException the javet exception
+     */
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     default void executeVoid() throws JavetException {
         execute(false);
     }
 
+    /**
+     * Execute zoned date time zoned date time.
+     *
+     * @return the zoned date time
+     * @throws JavetException the javet exception
+     */
     default ZonedDateTime executeZonedDateTime() throws JavetException {
         return executePrimitive();
     }

--- a/src/main/java/com/caoccao/javet/interop/JavetClassLoader.java
+++ b/src/main/java/com/caoccao/javet/interop/JavetClassLoader.java
@@ -23,11 +23,9 @@ import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.utils.SimpleMap;
 
 import java.io.DataInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
 
-@SuppressWarnings("unchecked")
 class JavetClassLoader extends ClassLoader {
     protected static final String JAVET_LIB_LOADER_CLASS_NAME = JavetLibLoader.class.getName();
     protected static final String NODE_NATIVE_CLASS_NAME = NodeNative.class.getName();
@@ -43,8 +41,8 @@ class JavetClassLoader extends ClassLoader {
 
     IV8Native getNative() throws JavetException {
         try {
-            Class classNative = loadClass(jsRuntimeType.isNode() ? NODE_NATIVE_CLASS_NAME : V8_NATIVE_CLASS_NAME);
-            Constructor constructor = classNative.getConstructor();
+            Class<?> classNative = loadClass(jsRuntimeType.isNode() ? NODE_NATIVE_CLASS_NAME : V8_NATIVE_CLASS_NAME);
+            Constructor<?> constructor = classNative.getConstructor();
             return (IV8Native) constructor.newInstance();
         } catch (Exception e) {
             e.printStackTrace(System.err);
@@ -57,8 +55,8 @@ class JavetClassLoader extends ClassLoader {
 
     void load() throws JavetException {
         try {
-            Class classJavetLibLoader = loadClass(JAVET_LIB_LOADER_CLASS_NAME);
-            Constructor constructor = classJavetLibLoader.getConstructor(JSRuntimeType.class);
+            Class<?> classJavetLibLoader = loadClass(JAVET_LIB_LOADER_CLASS_NAME);
+            Constructor<?> constructor = classJavetLibLoader.getConstructor(JSRuntimeType.class);
             Object javetLibLoader = constructor.newInstance(jsRuntimeType);
             classJavetLibLoader.getMethod(METHOD_LOAD).invoke(javetLibLoader);
         } catch (Exception e) {
@@ -77,6 +75,7 @@ class JavetClassLoader extends ClassLoader {
                 V8_NATIVE_CLASS_NAME.equals(name)) {
             String classPath = "/" + name.replace(".", "/") + ".class";
             try (InputStream inputStream = getClass().getResourceAsStream(classPath)) {
+                //noinspection ConstantConditions
                 byte[] buffer = new byte[inputStream.available()];
                 try (DataInputStream dataInputStream = new DataInputStream(inputStream)) {
                     dataInputStream.readFully(buffer);
@@ -84,9 +83,9 @@ class JavetClassLoader extends ClassLoader {
                     resolveClass(classJavetLibLoader);
                     return classJavetLibLoader;
                 }
-            } catch (IOException e) {
-                e.printStackTrace(System.err);
-                throw new ClassNotFoundException(name, e);
+            } catch (Throwable t) {
+                t.printStackTrace(System.err);
+                throw new ClassNotFoundException(name, t);
             }
         }
         return super.loadClass(name);

--- a/src/main/java/com/caoccao/javet/interop/JavetLibLoader.java
+++ b/src/main/java/com/caoccao/javet/interop/JavetLibLoader.java
@@ -30,7 +30,7 @@ import java.text.MessageFormat;
 import java.util.Objects;
 
 public final class JavetLibLoader {
-    static final String LIB_VERSION = "0.8.9";
+    static final String LIB_VERSION = "0.8.10";
     private static final String CHMOD = "chmod";
     private static final String XRR = "755";
     private static final String LIB_FILE_NAME_FORMAT = "libjavet-{0}-{1}-x86_64.v.{2}.{3}";

--- a/src/main/java/com/caoccao/javet/interop/JavetLibLoader.java
+++ b/src/main/java/com/caoccao/javet/interop/JavetLibLoader.java
@@ -40,7 +40,7 @@ public final class JavetLibLoader {
     private static final String OS_LINUX = "linux";
     private static final String OS_WINDOWS = "windows";
     private static final int BUFFER_LENGTH = 4096;
-    private JSRuntimeType jsRuntimeType;
+    private final JSRuntimeType jsRuntimeType;
     private boolean loaded;
 
     public JavetLibLoader(JSRuntimeType jsRuntimeType) {
@@ -61,6 +61,7 @@ public final class JavetLibLoader {
         boolean isLibFileLocked = false;
         if (libFile.exists()) {
             try {
+                //noinspection ResultOfMethodCallIgnored
                 libFile.delete();
             } catch (Exception e) {
                 isLibFileLocked = true;
@@ -70,17 +71,19 @@ public final class JavetLibLoader {
             byte[] buffer = new byte[BUFFER_LENGTH];
             try (InputStream inputStream = JavetLibLoader.class.getResourceAsStream(resourceFileName);
                  FileOutputStream outputStream = new FileOutputStream(libFile.getAbsolutePath())) {
-                while (true) {
-                    int length = inputStream.read(buffer);
-                    if (length == -1) {
-                        break;
+                if (inputStream != null) {
+                    while (true) {
+                        int length = inputStream.read(buffer);
+                        if (length == -1) {
+                            break;
+                        }
+                        outputStream.write(buffer, 0, length);
                     }
-                    outputStream.write(buffer, 0, length);
-                }
-                if (JavetOSUtils.IS_LINUX) {
-                    try {
-                        Runtime.getRuntime().exec(new String[]{CHMOD, XRR, libFile.getAbsolutePath()}).waitFor();
-                    } catch (Throwable e) {
+                    if (JavetOSUtils.IS_LINUX) {
+                        try {
+                            Runtime.getRuntime().exec(new String[]{CHMOD, XRR, libFile.getAbsolutePath()}).waitFor();
+                        } catch (Throwable ignored) {
+                        }
                     }
                 }
             } catch (Exception e) {

--- a/src/main/java/com/caoccao/javet/interop/NodeRuntime.java
+++ b/src/main/java/com/caoccao/javet/interop/NodeRuntime.java
@@ -17,13 +17,13 @@
 
 package com.caoccao.javet.interop;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.annotations.NodeModule;
 import com.caoccao.javet.enums.JSRuntimeType;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.node.modules.INodeModule;
 import com.caoccao.javet.node.modules.NodeModuleProcess;
 import com.caoccao.javet.utils.JavetResourceUtils;
-import com.caoccao.javet.values.primitive.V8ValueString;
 import com.caoccao.javet.values.reference.V8ValueFunction;
 import com.caoccao.javet.values.reference.V8ValueObject;
 
@@ -59,6 +59,7 @@ public class NodeRuntime extends V8Runtime {
         return JSRuntimeType.Node;
     }
 
+    @CheckReturnValue
     public <Module extends INodeModule> Module getNodeModule(
             Class<Module> nodeModuleClass) throws JavetException {
         if (!nodeModuleClass.isAnnotationPresent(NodeModule.class)) {
@@ -68,8 +69,9 @@ public class NodeRuntime extends V8Runtime {
         return getNodeModule(nodeModule.name(), nodeModuleClass);
     }
 
-    public <NodeModule extends INodeModule> NodeModule getNodeModule(
-            String name, Class<NodeModule> nodeModuleClass) throws JavetException {
+    @CheckReturnValue
+    public <NM extends INodeModule> NM getNodeModule(
+            String name, Class<NM> nodeModuleClass) throws JavetException {
         Objects.requireNonNull(name);
         INodeModule nodeModule = null;
         if (nodeModuleMap.containsKey(name)) {
@@ -84,7 +86,7 @@ public class NodeRuntime extends V8Runtime {
                 }
             }
             try {
-                Constructor<NodeModule> constructor = nodeModuleClass.getConstructor(
+                Constructor<NM> constructor = nodeModuleClass.getConstructor(
                         V8ValueObject.class, String.class);
                 nodeModule = constructor.newInstance(moduleObject, name);
                 nodeModuleMap.put(name, nodeModule);
@@ -92,7 +94,7 @@ public class NodeRuntime extends V8Runtime {
                 getLogger().logError(e, "Failed to create node module {0}.", name);
             }
         }
-        return (NodeModule) nodeModule;
+        return (NM) nodeModule;
     }
 
     public int getNodeModuleCount() {

--- a/src/main/java/com/caoccao/javet/interop/V8FunctionCallback.java
+++ b/src/main/java/com/caoccao/javet/interop/V8FunctionCallback.java
@@ -32,10 +32,9 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
-@SuppressWarnings("unchecked")
 public final class V8FunctionCallback {
 
-    private static Object convert(IJavetConverter converter, Class expectedClass, V8Value v8Value)
+    private static Object convert(IJavetConverter converter, Class<?> expectedClass, V8Value v8Value)
             throws JavetException {
         if (v8Value == null) {
             // This check is for null safety.
@@ -69,7 +68,7 @@ public final class V8FunctionCallback {
             if (convertedObject == null) {
                 return convert(converter, expectedClass, null);
             } else {
-                Class convertedObjectClass = convertedObject.getClass();
+                Class<?> convertedObjectClass = convertedObject.getClass();
                 if (expectedClass.isAssignableFrom(convertedObjectClass)) {
                     return convertedObject;
                 } else if (expectedClass.isPrimitive()) {
@@ -79,6 +78,7 @@ public final class V8FunctionCallback {
                      */
                     if (expectedClass == int.class) {
                         if (convertedObjectClass == Integer.class) {
+                            //noinspection UnnecessaryUnboxing
                             return ((Integer) convertedObject).intValue();
                         } else if (convertedObjectClass == Long.class) {
                             return ((Long) convertedObject).intValue();
@@ -88,9 +88,11 @@ public final class V8FunctionCallback {
                             return ((Byte) convertedObject).intValue();
                         }
                     } else if (expectedClass == boolean.class && convertedObjectClass == Boolean.class) {
+                        //noinspection UnnecessaryUnboxing
                         return ((Boolean) convertedObject).booleanValue();
                     } else if (expectedClass == double.class) {
                         if (convertedObjectClass == Double.class) {
+                            //noinspection UnnecessaryUnboxing
                             return ((Double) convertedObject).doubleValue();
                         } else if (convertedObjectClass == Float.class) {
                             return ((Float) convertedObject).doubleValue();
@@ -107,6 +109,7 @@ public final class V8FunctionCallback {
                         if (convertedObjectClass == Double.class) {
                             return ((Double) convertedObject).floatValue();
                         } else if (convertedObjectClass == Float.class) {
+                            //noinspection UnnecessaryUnboxing
                             return ((Float) convertedObject).floatValue();
                         } else if (convertedObjectClass == Integer.class) {
                             return ((Integer) convertedObject).floatValue();
@@ -119,6 +122,7 @@ public final class V8FunctionCallback {
                         }
                     } else if (expectedClass == long.class) {
                         if (convertedObjectClass == Long.class) {
+                            //noinspection UnnecessaryUnboxing
                             return ((Long) convertedObject).longValue();
                         } else if (convertedObjectClass == Integer.class) {
                             return ((Integer) convertedObject).longValue();
@@ -129,6 +133,7 @@ public final class V8FunctionCallback {
                         }
                     } else if (expectedClass == short.class) {
                         if (convertedObjectClass == Short.class) {
+                            //noinspection UnnecessaryUnboxing
                             return ((Short) convertedObject).shortValue();
                         } else if (convertedObjectClass == Integer.class) {
                             return ((Integer) convertedObject).shortValue();
@@ -139,6 +144,7 @@ public final class V8FunctionCallback {
                         }
                     } else if (expectedClass == byte.class) {
                         if (convertedObjectClass == Byte.class) {
+                            //noinspection UnnecessaryUnboxing
                             return ((Byte) convertedObject).byteValue();
                         } else if (convertedObjectClass == Integer.class) {
                             return ((Integer) convertedObject).byteValue();
@@ -149,6 +155,7 @@ public final class V8FunctionCallback {
                         }
                     } else if (expectedClass == char.class) {
                         if (convertedObjectClass == Character.class) {
+                            //noinspection UnnecessaryUnboxing
                             return ((Character) convertedObject).charValue();
                         } else if (convertedObjectClass == String.class) {
                             String convertedString = (String) convertedObject;
@@ -188,7 +195,7 @@ public final class V8FunctionCallback {
                  */
                 Method method = javetCallbackContext.getCallbackMethod();
                 Object callbackReceiver = javetCallbackContext.getCallbackReceiver();
-                Object resultObject = null;
+                Object resultObject;
                 if (javetCallbackContext.isThisObjectRequired()) {
                     values.add(thisObject);
                 }
@@ -216,7 +223,7 @@ public final class V8FunctionCallback {
                             Class<?> parameterClass = parameterTypes[i];
                             if (parameterClass.isArray() && i == parameterTypes.length - 1) {
                                 // VarArgs is special. It requires special API to manipulate the array.
-                                Class componentType = parameterClass.getComponentType();
+                                Class<?> componentType = parameterClass.getComponentType();
                                 Object varObject = Array.newInstance(componentType, length - i);
                                 for (int j = i; j < length; ++j) {
                                     Array.set(varObject, j - i,

--- a/src/main/java/com/caoccao/javet/interop/V8FunctionCallback.java
+++ b/src/main/java/com/caoccao/javet/interop/V8FunctionCallback.java
@@ -199,7 +199,14 @@ public final class V8FunctionCallback {
                     }
                 }
                 if (values.isEmpty()) {
-                    resultObject = method.invoke(callbackReceiver);
+                    if (method.isVarArgs()) {
+                        Class<?>[] parameterTypes = method.getParameterTypes();
+                        Class<?> parameterClass = parameterTypes[parameterTypes.length - 1];
+                        Object varObject = Array.newInstance(parameterClass.getComponentType(), 0);
+                        resultObject = method.invoke(callbackReceiver, varObject);
+                    } else {
+                        resultObject = method.invoke(callbackReceiver);
+                    }
                 } else {
                     final int length = values.size();
                     List<Object> objectValues = new ArrayList<>();

--- a/src/main/java/com/caoccao/javet/interop/V8Inspector.java
+++ b/src/main/java/com/caoccao/javet/interop/V8Inspector.java
@@ -27,10 +27,10 @@ import java.util.Objects;
 
 public final class V8Inspector {
     private IJavetLogger logger;
-    private String name;
-    private List<IV8InspectorListener> listeners;
-    private IV8Native v8Native;
-    private V8Runtime v8Runtime;
+    private final String name;
+    private final List<IV8InspectorListener> listeners;
+    private final IV8Native v8Native;
+    private final V8Runtime v8Runtime;
 
     V8Inspector(V8Runtime v8Runtime, String name, IV8Native v8Native) {
         logger = v8Runtime.getLogger();
@@ -108,6 +108,7 @@ public final class V8Inspector {
         }
     }
 
+    @SuppressWarnings("RedundantThrows")
     public void sendRequest(String message) throws JavetException {
         logger.logDebug("Sending request: {0}", message);
         for (IV8InspectorListener listener : listeners) {

--- a/src/main/java/com/caoccao/javet/interop/V8Locker.java
+++ b/src/main/java/com/caoccao/javet/interop/V8Locker.java
@@ -29,9 +29,9 @@ import java.util.Objects;
  * It's designed for performance sensitive scenarios.
  */
 public final class V8Locker implements IJavetClosable {
-    private long threadId;
-    private IV8Native v8Native;
-    private V8Runtime v8Runtime;
+    private final long threadId;
+    private final IV8Native v8Native;
+    private final V8Runtime v8Runtime;
 
     /**
      * Instantiates a new V8 locker.

--- a/src/main/java/com/caoccao/javet/interop/V8Notifier.java
+++ b/src/main/java/com/caoccao/javet/interop/V8Notifier.java
@@ -26,7 +26,7 @@ import java.lang.management.MemoryNotificationInfo;
 import java.util.concurrent.ConcurrentHashMap;
 
 public final class V8Notifier implements NotificationListener {
-    private ConcurrentHashMap<Long, V8Runtime> v8RuntimeMap;
+    private final ConcurrentHashMap<Long, V8Runtime> v8RuntimeMap;
 
     public V8Notifier(ConcurrentHashMap<Long, V8Runtime> v8RuntimeMap) {
         this.v8RuntimeMap = v8RuntimeMap;
@@ -48,7 +48,7 @@ public final class V8Notifier implements NotificationListener {
         NotificationEmitter notificationEmitter = (NotificationEmitter) ManagementFactory.getMemoryMXBean();
         try {
             notificationEmitter.removeNotificationListener(this, null, null);
-        } catch (ListenerNotFoundException e) {
+        } catch (ListenerNotFoundException ignored) {
         }
         notificationEmitter.addNotificationListener(this, null, null);
     }
@@ -57,7 +57,7 @@ public final class V8Notifier implements NotificationListener {
         try {
             NotificationEmitter notificationEmitter = (NotificationEmitter) ManagementFactory.getMemoryMXBean();
             notificationEmitter.removeNotificationListener(this, null, null);
-        } catch (ListenerNotFoundException e) {
+        } catch (ListenerNotFoundException ignored) {
         }
     }
 }

--- a/src/main/java/com/caoccao/javet/interop/V8Runtime.java
+++ b/src/main/java/com/caoccao/javet/interop/V8Runtime.java
@@ -133,6 +133,7 @@ public class V8Runtime implements IJavetClosable, IV8Creatable, IV8Convertible {
                 handle, iV8ValueObject.getHandle(), iV8ValueObject.getType().getId(), v8Values));
     }
 
+    @SuppressWarnings("RedundantThrows")
     public void clearWeak(IV8ValueReference iV8ValueReference) throws JavetException {
         v8Native.clearWeak(handle, iV8ValueReference.getHandle(), iV8ValueReference.getType().getId());
     }
@@ -144,11 +145,7 @@ public class V8Runtime implements IJavetClosable, IV8Creatable, IV8Convertible {
 
     @Override
     public void close() throws JavetException {
-        if (pooled) {
-            close(false);
-        } else {
-            close(true);
-        }
+        close(!pooled);
     }
 
     public void close(boolean forceClose) throws JavetException {
@@ -198,6 +195,7 @@ public class V8Runtime implements IJavetClosable, IV8Creatable, IV8Convertible {
     }
 
     @Override
+    @SuppressWarnings("RedundantThrows")
     public V8ValueBoolean createV8ValueBoolean(boolean booleanValue) throws JavetException {
         return booleanValue ?
                 cachedV8ValueBooleans[V8_VALUE_BOOLEAN_TRUE_INDEX] :
@@ -300,6 +298,7 @@ public class V8Runtime implements IJavetClosable, IV8Creatable, IV8Convertible {
         return v8Value;
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     public <T extends V8Value> int decorateV8Values(T... v8Values) throws JavetException {
         if (v8Values != null && v8Values.length > 0) {
             for (T v8Value : v8Values) {
@@ -367,6 +366,7 @@ public class V8Runtime implements IJavetClosable, IV8Creatable, IV8Convertible {
         return new V8StringExecutor(this, scriptString);
     }
 
+    @SuppressWarnings("RedundantThrows")
     public int getIdentityHash(IV8ValueReference iV8ValueReference) throws JavetException {
         return v8Native.getIdentityHash(handle, iV8ValueReference.getHandle(), iV8ValueReference.getType().getId());
     }
@@ -450,6 +450,7 @@ public class V8Runtime implements IJavetClosable, IV8Creatable, IV8Convertible {
         return v8Native.getSize(handle, iV8ValueKeyContainer.getHandle(), iV8ValueKeyContainer.getType().getId());
     }
 
+    @SuppressWarnings("RedundantThrows")
     public String getSourceCode(IV8ValueFunction iV8ValueFunction) throws JavetException {
         return v8Native.getSourceCode(handle, iV8ValueFunction.getHandle(), iV8ValueFunction.getType().getId());
     }
@@ -582,14 +583,17 @@ public class V8Runtime implements IJavetClosable, IV8Creatable, IV8Convertible {
                 handle, iV8Module.getHandle(), iV8Module.getType().getId()));
     }
 
+    @SuppressWarnings("RedundantThrows")
     public int moduleGetScriptId(IV8Module iV8Module) throws JavetException {
         return v8Native.moduleGetScriptId(handle, iV8Module.getHandle(), iV8Module.getType().getId());
     }
 
+    @SuppressWarnings("RedundantThrows")
     public int moduleGetStatus(IV8Module iV8Module) throws JavetException {
         return v8Native.moduleGetStatus(handle, iV8Module.getHandle(), iV8Module.getType().getId());
     }
 
+    @SuppressWarnings("RedundantThrows")
     public boolean moduleInstantiate(IV8Module iV8Module) throws JavetException {
         return v8Native.moduleInstantiate(handle, iV8Module.getHandle(), iV8Module.getType().getId());
     }
@@ -655,7 +659,8 @@ public class V8Runtime implements IJavetClosable, IV8Creatable, IV8Convertible {
         }
     }
 
-    public void removeReference(IV8ValueReference iV8ValueReference) {
+    @SuppressWarnings("RedundantThrows")
+    public void removeReference(IV8ValueReference iV8ValueReference) throws JavetException {
         final long referenceHandle = iV8ValueReference.getHandle();
         if (referenceMap.containsKey(referenceHandle)) {
             final int referenceType = iV8ValueReference.getType().getId();
@@ -743,6 +748,7 @@ public class V8Runtime implements IJavetClosable, IV8Creatable, IV8Convertible {
      * @return the self
      * @throws JavetException the javet exception
      */
+    @SuppressWarnings("UnusedReturnValue")
     public V8Runtime resetIsolate() throws JavetException {
         removeAllReferences();
         v8Native.resetV8Isolate(handle, globalName);
@@ -775,6 +781,7 @@ public class V8Runtime implements IJavetClosable, IV8Creatable, IV8Convertible {
         return v8Native.set(handle, iV8ValueObject.getHandle(), iV8ValueObject.getType().getId(), key, value);
     }
 
+    @SuppressWarnings("RedundantThrows")
     public boolean setAccessor(
             IV8ValueObject iV8ValueObject,
             String propertyName,
@@ -795,6 +802,7 @@ public class V8Runtime implements IJavetClosable, IV8Creatable, IV8Convertible {
         return v8Native.setProperty(handle, iV8ValueObject.getHandle(), iV8ValueObject.getType().getId(), key, value);
     }
 
+    @SuppressWarnings("RedundantThrows")
     public boolean setSourceCode(IV8ValueFunction iV8ValueFunction, String sourceCode) throws JavetException {
         return v8Native.setSourceCode(handle, iV8ValueFunction.getHandle(), iV8ValueFunction.getType().getId(), sourceCode);
     }
@@ -821,7 +829,7 @@ public class V8Runtime implements IJavetClosable, IV8Creatable, IV8Convertible {
     }
 
     @Override
-    public <T extends Object, V extends V8Value> T toObject(V v8Value) throws JavetException {
+    public <T, V extends V8Value> T toObject(V v8Value) throws JavetException {
         return (T) converter.toObject(v8Value);
     }
 
@@ -834,7 +842,7 @@ public class V8Runtime implements IJavetClosable, IV8Creatable, IV8Convertible {
     }
 
     @Override
-    public <T extends Object, V extends V8Value> V toV8Value(T object) throws JavetException {
+    public <T, V extends V8Value> V toV8Value(T object) throws JavetException {
         return converter.toV8Value(this, object);
     }
 }

--- a/src/main/java/com/caoccao/javet/interop/converters/IJavetConverter.java
+++ b/src/main/java/com/caoccao/javet/interop/converters/IJavetConverter.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.interop.converters;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interop.V8Runtime;
 import com.caoccao.javet.utils.JavetResourceUtils;
@@ -70,5 +71,6 @@ public interface IJavetConverter {
         }
     }
 
+    @CheckReturnValue
     <T extends V8Value> T toV8Value(V8Runtime v8Runtime, Object object) throws JavetException;
 }

--- a/src/main/java/com/caoccao/javet/interop/converters/JavetObjectConverter.java
+++ b/src/main/java/com/caoccao/javet/interop/converters/JavetObjectConverter.java
@@ -63,7 +63,7 @@ public class JavetObjectConverter extends JavetPrimitiveConverter {
         } else if (v8Value instanceof V8ValueMap) {
             V8ValueMap v8ValueMap = (V8ValueMap) v8Value;
             Map<String, Object> map = createEntityMap();
-            v8ValueMap.forEach((key, value) -> map.put(key.toString(), toObject(value)));
+            v8ValueMap.forEach((V8Value key, V8Value value) -> map.put(key.toString(), toObject(value)));
             return map;
         } else if (v8Value instanceof V8ValueTypedArray) {
             V8ValueTypedArray v8ValueTypedArray = (V8ValueTypedArray) v8Value;

--- a/src/main/java/com/caoccao/javet/interop/converters/JavetObjectConverter.java
+++ b/src/main/java/com/caoccao/javet/interop/converters/JavetObjectConverter.java
@@ -17,11 +17,12 @@
 
 package com.caoccao.javet.interop.converters;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.entities.JavetEntityMap;
+import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interop.V8Runtime;
 import com.caoccao.javet.values.V8Value;
-import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.values.reference.*;
 
 import java.util.*;
@@ -47,7 +48,7 @@ public class JavetObjectConverter extends JavetPrimitiveConverter {
     @Override
     public Object toObject(V8Value v8Value) throws JavetException {
         Object returnObject = super.toObject(v8Value);
-        if (returnObject == null || !(returnObject instanceof V8Value)) {
+        if (!(returnObject instanceof V8Value)) {
             return returnObject;
         }
         if (v8Value instanceof V8ValueArray) {
@@ -109,6 +110,7 @@ public class JavetObjectConverter extends JavetPrimitiveConverter {
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T toV8Value(V8Runtime v8Runtime, Object object) throws JavetException {
         V8Value v8Value = super.toV8Value(v8Runtime, object);
         if (v8Value != null && !(v8Value.isUndefined())) {
@@ -116,7 +118,7 @@ public class JavetObjectConverter extends JavetPrimitiveConverter {
         }
         if (isEntityMap(object)) {
             V8ValueMap v8ValueMap = v8Runtime.createV8ValueMap();
-            Map mapObject = (Map) object;
+            Map<?, ?> mapObject = (Map<?, ?>) object;
             for (Object key : mapObject.keySet()) {
                 try (V8Value childV8Value = toV8Value(v8Runtime, mapObject.get(key))) {
                     String childStringKey = key instanceof String ? (String) key : key.toString();
@@ -126,7 +128,7 @@ public class JavetObjectConverter extends JavetPrimitiveConverter {
             v8Value = v8ValueMap;
         } else if (object instanceof Map) {
             V8ValueObject v8ValueObject = v8Runtime.createV8ValueObject();
-            Map mapObject = (Map) object;
+            Map<?, ?> mapObject = (Map<?, ?>) object;
             for (Object key : mapObject.keySet()) {
                 try (V8Value childV8Value = toV8Value(v8Runtime, mapObject.get(key))) {
                     String childStringKey = key instanceof String ? (String) key : key.toString();
@@ -136,7 +138,7 @@ public class JavetObjectConverter extends JavetPrimitiveConverter {
             v8Value = v8ValueObject;
         } else if (object instanceof Set) {
             V8ValueSet v8ValueSet = v8Runtime.createV8ValueSet();
-            Set setObject = (Set) object;
+            Set<?> setObject = (Set<?>) object;
             for (Object item : setObject) {
                 try (V8Value childV8Value = toV8Value(v8Runtime, item)) {
                     v8ValueSet.add(childV8Value);
@@ -145,7 +147,7 @@ public class JavetObjectConverter extends JavetPrimitiveConverter {
             v8Value = v8ValueSet;
         } else if (object instanceof Collection) {
             V8ValueArray v8ValueArray = v8Runtime.createV8ValueArray();
-            for (Object item : (Collection) object) {
+            for (Object item : (Collection<?>) object) {
                 try (V8Value childV8Value = toV8Value(v8Runtime, item)) {
                     v8ValueArray.push(childV8Value);
                 }

--- a/src/main/java/com/caoccao/javet/interop/converters/JavetPrimitiveConverter.java
+++ b/src/main/java/com/caoccao/javet/interop/converters/JavetPrimitiveConverter.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.interop.converters;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interop.V8Runtime;
 import com.caoccao.javet.values.V8Value;
@@ -34,22 +35,24 @@ public class JavetPrimitiveConverter implements IJavetConverter {
         if (v8Value == null || v8Value.isNull() || v8Value.isUndefined()) {
             return null;
         } else if (v8Value instanceof V8ValuePrimitive) {
-            return ((V8ValuePrimitive) v8Value).getValue();
+            return ((V8ValuePrimitive<?>) v8Value).getValue();
         }
         return v8Value;
     }
 
+    @SuppressWarnings("ConstantConditions")
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T toV8Value(V8Runtime v8Runtime, Object object) throws JavetException {
         /*
          * The following test is based on statistical analysis
          * so that the performance can be maximized.
          */
-        V8Value v8Value = null;
+        V8Value v8Value;
         if (object == null) {
             v8Value = v8Runtime.createV8ValueNull();
         } else if (object.getClass().isPrimitive()) {
-            Class objectClass = object.getClass();
+            Class<?> objectClass = object.getClass();
             if (objectClass == int.class) {
                 v8Value = v8Runtime.createV8ValueInteger((int) object);
             } else if (objectClass == boolean.class) {

--- a/src/main/java/com/caoccao/javet/interop/engine/IJavetEngine.java
+++ b/src/main/java/com/caoccao/javet/interop/engine/IJavetEngine.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.interop.engine;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interfaces.IJavetClosable;
 import com.caoccao.javet.interop.V8Runtime;
@@ -27,8 +28,10 @@ public interface IJavetEngine<R extends V8Runtime> extends IJavetClosable {
 
     R getV8Runtime() throws JavetException;
 
+    @CheckReturnValue
     IJavetEngineGuard getGuard();
 
+    @CheckReturnValue
     IJavetEngineGuard getGuard(long timeoutMillis);
 
     boolean isActive();

--- a/src/main/java/com/caoccao/javet/interop/engine/IJavetEnginePool.java
+++ b/src/main/java/com/caoccao/javet/interop/engine/IJavetEnginePool.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.interop.engine;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interfaces.IJavetClosable;
 import com.caoccao.javet.interop.V8Runtime;
@@ -27,6 +28,7 @@ public interface IJavetEnginePool<R extends V8Runtime> extends IJavetClosable {
 
     JavetEngineConfig getConfig();
 
+    @CheckReturnValue
     IJavetEngine<R> getEngine() throws JavetException;
 
     int getIdleEngineCount();

--- a/src/main/java/com/caoccao/javet/interop/engine/JavetEngine.java
+++ b/src/main/java/com/caoccao/javet/interop/engine/JavetEngine.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.interop.engine;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interop.V8Runtime;
 import com.caoccao.javet.utils.JavetDateTimeUtils;
@@ -24,7 +25,6 @@ import com.caoccao.javet.utils.JavetDateTimeUtils;
 import java.time.ZonedDateTime;
 import java.util.Objects;
 
-@SuppressWarnings("unchecked")
 public class JavetEngine<R extends V8Runtime> implements IJavetEngine<R> {
     protected boolean active;
     protected IJavetEnginePool<R> iJavetEnginePool;
@@ -67,11 +67,13 @@ public class JavetEngine<R extends V8Runtime> implements IJavetEngine<R> {
     }
 
     @Override
+    @CheckReturnValue
     public IJavetEngineGuard getGuard() {
         return getGuard(iJavetEnginePool.getConfig().getDefaultEngineGuardTimeoutMillis());
     }
 
     @Override
+    @CheckReturnValue
     public IJavetEngineGuard getGuard(long timeoutMillis) {
         return new JavetEngineGuard(this, v8Runtime, timeoutMillis);
     }
@@ -83,7 +85,7 @@ public class JavetEngine<R extends V8Runtime> implements IJavetEngine<R> {
     @Override
     public R getV8Runtime() throws JavetException {
         setActive(true);
-        return (R) v8Runtime;
+        return v8Runtime;
     }
 
     /**

--- a/src/main/java/com/caoccao/javet/interop/engine/JavetEngineConfig.java
+++ b/src/main/java/com/caoccao/javet/interop/engine/JavetEngineConfig.java
@@ -58,6 +58,7 @@ public final class JavetEngineConfig {
         reset();
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     public JavetEngineConfig reset() {
         javetLogger = DEFAULT_JAVET_LOGGER;
         globalName = DEFAULT_GLOBAL_NAME;
@@ -109,6 +110,7 @@ public final class JavetEngineConfig {
         return executorService;
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     JavetEngineConfig setExecutorService(ExecutorService executorService) {
         this.executorService = executorService;
         return this;
@@ -137,6 +139,7 @@ public final class JavetEngineConfig {
         return engineGuardCheckIntervalMillis;
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     public JavetEngineConfig setEngineGuardCheckIntervalMillis(int engineGuardCheckIntervalMillis) {
         this.engineGuardCheckIntervalMillis = engineGuardCheckIntervalMillis;
         return this;
@@ -219,6 +222,7 @@ public final class JavetEngineConfig {
         return poolDaemonCheckIntervalMillis;
     }
 
+    @SuppressWarnings("UnusedReturnValue")
     public JavetEngineConfig setPoolDaemonCheckIntervalMillis(int poolDaemonCheckIntervalMillis) {
         this.poolDaemonCheckIntervalMillis = poolDaemonCheckIntervalMillis;
         return this;

--- a/src/main/java/com/caoccao/javet/interop/engine/JavetEngineGuard.java
+++ b/src/main/java/com/caoccao/javet/interop/engine/JavetEngineGuard.java
@@ -33,14 +33,14 @@ public class JavetEngineGuard implements IJavetEngineGuard {
     protected static final boolean IS_IN_DEBUG_MODE = ManagementFactory.getRuntimeMXBean().
             getInputArguments().toString().indexOf("-agentlib:jdwp") > 0;
 
-    protected Future future;
-    protected IJavetEngine iJavetEngine;
+    protected Future<?> future;
+    protected IJavetEngine<?> iJavetEngine;
     protected boolean quitting;
     protected boolean skipInDebugMode;
     protected long timeoutMillis;
     protected V8Runtime v8Runtime;
 
-    public JavetEngineGuard(IJavetEngine iJavetEngine, V8Runtime v8Runtime, long timeoutMills) {
+    public JavetEngineGuard(IJavetEngine<?> iJavetEngine, V8Runtime v8Runtime, long timeoutMills) {
         Objects.requireNonNull(iJavetEngine);
         this.iJavetEngine = iJavetEngine;
         quitting = false;
@@ -112,11 +112,11 @@ public class JavetEngineGuard implements IJavetEngineGuard {
                     }
                 } catch (Exception e) {
                     logger.error(e.getMessage(), e);
-                } finally {
-                    break;
                 }
+                break;
             } else {
                 try {
+                    //noinspection BusyWait
                     Thread.sleep(config.getEngineGuardCheckIntervalMillis());
                 } catch (InterruptedException e) {
                     // It's closed.

--- a/src/main/java/com/caoccao/javet/interop/engine/JavetEnginePool.java
+++ b/src/main/java/com/caoccao/javet/interop/engine/JavetEnginePool.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class JavetEnginePool<R extends V8Runtime> implements IJavetEnginePool<R>, Runnable {
+    protected static final String JAVET_DAEMON_THREAD_NAME = "Javet Daemon";
     protected final Object externalLock;
     protected JavetEngineConfig config;
     protected ConcurrentLinkedQueue<JavetEngine<R>> activeEngineList;
@@ -234,6 +235,8 @@ public class JavetEnginePool<R extends V8Runtime> implements IJavetEnginePool<R>
         quitting = false;
         config.setExecutorService(Executors.newCachedThreadPool());
         daemonThread = new Thread(this);
+        daemonThread.setDaemon(true);
+        daemonThread.setName(JAVET_DAEMON_THREAD_NAME);
         daemonThread.start();
         active = true;
         logger.debug("JavetEnginePool.startDaemon() ends.");

--- a/src/main/java/com/caoccao/javet/interop/executors/BaseV8Executor.java
+++ b/src/main/java/com/caoccao/javet/interop/executors/BaseV8Executor.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.interop.executors;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interop.V8Runtime;
 import com.caoccao.javet.interop.V8ScriptOrigin;
@@ -37,12 +38,15 @@ public abstract class BaseV8Executor implements IV8Executor {
     }
 
     @Override
+    @CheckReturnValue
     public abstract V8Script compileScript(boolean resultRequired) throws JavetException;
 
     @Override
+    @CheckReturnValue
     public abstract V8Module compileV8Module(boolean resultRequired) throws JavetException;
 
     @Override
+    @CheckReturnValue
     public abstract <T extends V8Value> T execute(boolean resultRequired) throws JavetException;
 
     @Override

--- a/src/main/java/com/caoccao/javet/interop/executors/IV8Executor.java
+++ b/src/main/java/com/caoccao/javet/interop/executors/IV8Executor.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.interop.executors;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interop.IV8Executable;
 import com.caoccao.javet.interop.NodeRuntime;
@@ -31,24 +32,29 @@ import com.caoccao.javet.values.reference.V8Script;
 import java.io.File;
 import java.nio.file.Path;
 
-@SuppressWarnings("unchecked")
 public interface IV8Executor extends IV8Executable {
+    @CheckReturnValue
     default V8Script compileScript() throws JavetException {
         return compileScript(true);
     }
 
+    @CheckReturnValue
     V8Script compileScript(boolean resultRequired) throws JavetException;
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     default void compileScriptVoid() throws JavetException {
         compileScript(false);
     }
 
+    @CheckReturnValue
     default V8Module compileV8Module() throws JavetException {
         return compileV8Module(true);
     }
 
+    @CheckReturnValue
     V8Module compileV8Module(boolean resultRequired) throws JavetException;
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     default void compileV8ModuleVoid() throws JavetException {
         compileV8Module(false);
     }
@@ -87,12 +93,13 @@ public interface IV8Executor extends IV8Executable {
     V8ScriptOrigin getV8ScriptOrigin();
 
     @Override
-    default <T extends Object, V extends V8Value> T toObject(V v8Value) throws JavetException {
+    default <T, V extends V8Value> T toObject(V v8Value) throws JavetException {
         return getV8Runtime().toObject(v8Value);
     }
 
     @Override
-    default <T extends Object, V extends V8Value> V toV8Value(T object) throws JavetException {
+    @CheckReturnValue
+    default <T, V extends V8Value> V toV8Value(T object) throws JavetException {
         return getV8Runtime().toV8Value(object);
     }
 }

--- a/src/main/java/com/caoccao/javet/interop/executors/V8StringExecutor.java
+++ b/src/main/java/com/caoccao/javet/interop/executors/V8StringExecutor.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.interop.executors;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interop.V8Runtime;
 import com.caoccao.javet.values.V8Value;
@@ -36,11 +37,13 @@ public class V8StringExecutor extends BaseV8Executor {
     }
 
     @Override
+    @CheckReturnValue
     public V8Script compileScript(boolean resultRequired) throws JavetException {
         return v8Runtime.compileScript(getScriptString(), v8ScriptOrigin, resultRequired);
     }
 
     @Override
+    @CheckReturnValue
     public V8Module compileV8Module(boolean resultRequired) throws JavetException {
         return v8Runtime.compileV8Module(getScriptString(), v8ScriptOrigin, resultRequired);
     }
@@ -51,6 +54,7 @@ public class V8StringExecutor extends BaseV8Executor {
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T execute(boolean resultRequired) throws JavetException {
         return v8Runtime.execute(getScriptString(), v8ScriptOrigin, resultRequired);
     }

--- a/src/main/java/com/caoccao/javet/node/modules/NodeModuleProcess.java
+++ b/src/main/java/com/caoccao/javet/node/modules/NodeModuleProcess.java
@@ -19,8 +19,6 @@ package com.caoccao.javet.node.modules;
 
 import com.caoccao.javet.annotations.NodeModule;
 import com.caoccao.javet.exceptions.JavetException;
-import com.caoccao.javet.interop.V8FunctionCallback;
-import com.caoccao.javet.utils.JavetCallbackContext;
 import com.caoccao.javet.values.primitive.V8ValueString;
 import com.caoccao.javet.values.reference.V8ValueFunction;
 import com.caoccao.javet.values.reference.V8ValueObject;
@@ -38,15 +36,15 @@ public class NodeModuleProcess extends BaseNodeModule {
         super(moduleObject, name);
     }
 
-    public Path getWorkingDirectory() throws JavetException {
+    public Path getWorkingDirectory() {
         return new File(moduleObject.invokeString(FUNCTION_CWD)).toPath();
-    }
-
-    public void on(String eventName, V8ValueFunction v8ValueFunction) throws JavetException {
-        moduleObject.invokeVoid(FUNCTION_ON, new V8ValueString(eventName), v8ValueFunction);
     }
 
     public void setWorkingDirectory(Path path) throws JavetException {
         moduleObject.invokeVoid(FUNCTION_CHDIR, new V8ValueString(path.toAbsolutePath().toString()));
+    }
+
+    public void on(String eventName, V8ValueFunction v8ValueFunction) throws JavetException {
+        moduleObject.invokeVoid(FUNCTION_ON, new V8ValueString(eventName), v8ValueFunction);
     }
 }

--- a/src/main/java/com/caoccao/javet/utils/JavetCallbackContext.java
+++ b/src/main/java/com/caoccao/javet/utils/JavetCallbackContext.java
@@ -26,11 +26,11 @@ public final class JavetCallbackContext {
             "Callback receiver or callback method is invalid";
     private static final String ERROR_JAVET_CALLBACK_CONTEXT_HANDLE_IS_INVALID =
             "Javet callback context handle is invalid";
-    private Method callbackMethod;
-    private Object callbackReceiver;
+    private final Method callbackMethod;
+    private final Object callbackReceiver;
     private long handle;
-    private boolean returnResult;
-    private boolean thisObjectRequired;
+    private final boolean returnResult;
+    private final boolean thisObjectRequired;
 
     public JavetCallbackContext(
             Object callbackReceiver,

--- a/src/main/java/com/caoccao/javet/utils/JavetDefaultLogger.java
+++ b/src/main/java/com/caoccao/javet/utils/JavetDefaultLogger.java
@@ -61,7 +61,7 @@ public class JavetDefaultLogger implements IJavetLogger {
                 cause.printStackTrace(printStream);
                 logger.severe(byteArrayOutputStream.toString(StandardCharsets.UTF_8.name()));
             }
-        } catch (IOException e) {
+        } catch (IOException ignored) {
         }
     }
 

--- a/src/main/java/com/caoccao/javet/utils/JavetResourceUtils.java
+++ b/src/main/java/com/caoccao/javet/utils/JavetResourceUtils.java
@@ -40,7 +40,7 @@ public final class JavetResourceUtils {
         if (object instanceof IJavetClosable) {
             try {
                 ((IJavetClosable) object).close();
-            } catch (JavetException e) {
+            } catch (JavetException ignored) {
             }
         } else if (object instanceof V8Value[]) {
             for (V8Value v8Value : (V8Value[]) object) {
@@ -51,7 +51,7 @@ public final class JavetResourceUtils {
                 safeClose(o);
             }
         } else if (object instanceof Collection) {
-            for (Object o : (Collection) object) {
+            for (Object o : (Collection<?>) object) {
                 safeClose(o);
             }
         }

--- a/src/main/java/com/caoccao/javet/utils/SimpleFreeMarkerFormat.java
+++ b/src/main/java/com/caoccao/javet/utils/SimpleFreeMarkerFormat.java
@@ -66,20 +66,17 @@ public final class SimpleFreeMarkerFormat {
                     }
                     break;
                 case CHAR_VARIABLE_CLOSE:
-                    switch (state) {
-                        case Variable:
-                            String variableName = stringBuilderVariable.toString();
-                            Object parameter = parameters.get(variableName);
-                            if (parameter == null) {
-                                parameter = STRING_NULL;
-                            }
-                            stringBuilderMessage.append(parameter);
-                            stringBuilderVariable.setLength(0);
-                            state = State.Text;
-                            break;
-                        default:
-                            stringBuilderMessage.append(c);
-                            break;
+                    if (state == State.Variable) {
+                        String variableName = stringBuilderVariable.toString();
+                        Object parameter = parameters.get(variableName);
+                        if (parameter == null) {
+                            parameter = STRING_NULL;
+                        }
+                        stringBuilderMessage.append(parameter);
+                        stringBuilderVariable.setLength(0);
+                        state = State.Text;
+                    } else {
+                        stringBuilderMessage.append(c);
                     }
                     break;
                 default:

--- a/src/main/java/com/caoccao/javet/utils/V8ValueUtils.java
+++ b/src/main/java/com/caoccao/javet/utils/V8ValueUtils.java
@@ -35,8 +35,6 @@ public final class V8ValueUtils {
         if (delimiter == null) {
             delimiter = EMPTY;
         }
-        return String.join(
-                delimiter,
-                Arrays.stream(v8Values).map(V8Value::toString).collect(Collectors.toList()));
+        return Arrays.stream(v8Values).map(V8Value::toString).collect(Collectors.joining(delimiter));
     }
 }

--- a/src/main/java/com/caoccao/javet/utils/receivers/JavetCallbackReceiver.java
+++ b/src/main/java/com/caoccao/javet/utils/receivers/JavetCallbackReceiver.java
@@ -19,7 +19,6 @@ package com.caoccao.javet.utils.receivers;
 
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interop.V8Runtime;
-import com.caoccao.javet.utils.JavetOSUtils;
 import com.caoccao.javet.values.V8Value;
 import com.caoccao.javet.values.reference.V8ValueArray;
 
@@ -33,6 +32,7 @@ import java.util.Objects;
  * It is supposed to provide a common ground for customized V8 callback receiver.
  */
 public class JavetCallbackReceiver implements IJavetCallbackReceiver {
+    protected static final String COMMA = ",";
     /**
      * The V8 runtime.
      */
@@ -116,6 +116,6 @@ public class JavetCallbackReceiver implements IJavetCallbackReceiver {
         for (V8Value arg : args) {
             stringList.add(arg == null ? null : arg.toString());
         }
-        return String.join(JavetOSUtils.LINE_SEPARATOR, stringList);
+        return String.join(COMMA, stringList);
     }
 }

--- a/src/main/java/com/caoccao/javet/utils/receivers/JavetCallbackReceiver.java
+++ b/src/main/java/com/caoccao/javet/utils/receivers/JavetCallbackReceiver.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.utils.receivers;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interop.V8Runtime;
 import com.caoccao.javet.values.V8Value;
@@ -60,6 +61,7 @@ public class JavetCallbackReceiver implements IJavetCallbackReceiver {
      * @return the V8 value
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     public V8Value echo(V8Value arg) throws JavetException {
         return arg.toClone();
     }
@@ -73,6 +75,7 @@ public class JavetCallbackReceiver implements IJavetCallbackReceiver {
      * @return the V8 value array
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     public V8ValueArray echo(V8Value... args) throws JavetException {
         V8ValueArray v8ValueArray = v8Runtime.createV8ValueArray();
         for (V8Value arg : args) {

--- a/src/main/java/com/caoccao/javet/values/V8Value.java
+++ b/src/main/java/com/caoccao/javet/values/V8Value.java
@@ -17,13 +17,13 @@
 
 package com.caoccao.javet.values;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetError;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interop.V8Runtime;
 
 import java.util.Objects;
 
-@SuppressWarnings("unchecked")
 public abstract class V8Value extends V8Data implements IV8Value {
     protected V8Runtime v8Runtime;
 
@@ -44,6 +44,7 @@ public abstract class V8Value extends V8Data implements IV8Value {
     public abstract boolean equals(V8Value v8Value) throws JavetException;
 
     @Override
+    @CheckReturnValue
     public abstract <T extends V8Value> T toClone() throws JavetException;
 
     public V8Runtime getV8Runtime() {

--- a/src/main/java/com/caoccao/javet/values/primitive/V8ValueBoolean.java
+++ b/src/main/java/com/caoccao/javet/values/primitive/V8ValueBoolean.java
@@ -35,6 +35,6 @@ public class V8ValueBoolean extends V8ValuePrimitive<Boolean> {
     }
 
     public boolean toPrimitive() {
-        return value.booleanValue();
+        return value;
     }
 }

--- a/src/main/java/com/caoccao/javet/values/primitive/V8ValueDouble.java
+++ b/src/main/java/com/caoccao/javet/values/primitive/V8ValueDouble.java
@@ -47,6 +47,6 @@ public class V8ValueDouble extends V8ValuePrimitive<Double> {
     }
 
     public double toPrimitive() {
-        return value.doubleValue();
+        return value;
     }
 }

--- a/src/main/java/com/caoccao/javet/values/primitive/V8ValueInteger.java
+++ b/src/main/java/com/caoccao/javet/values/primitive/V8ValueInteger.java
@@ -22,7 +22,7 @@ import com.caoccao.javet.exceptions.JavetException;
 @SuppressWarnings("unchecked")
 public final class V8ValueInteger extends V8ValuePrimitive<Integer> {
     public V8ValueInteger() {
-        this(Integer.valueOf(0));
+        this(0);
     }
 
     public V8ValueInteger(int value) {
@@ -35,6 +35,6 @@ public final class V8ValueInteger extends V8ValuePrimitive<Integer> {
     }
 
     public int toPrimitive() {
-        return value.intValue();
+        return value;
     }
 }

--- a/src/main/java/com/caoccao/javet/values/primitive/V8ValueLong.java
+++ b/src/main/java/com/caoccao/javet/values/primitive/V8ValueLong.java
@@ -22,7 +22,7 @@ import com.caoccao.javet.exceptions.JavetException;
 @SuppressWarnings("unchecked")
 public final class V8ValueLong extends V8ValuePrimitive<Long> {
     public V8ValueLong() {
-        this(Long.valueOf(0));
+        this(0L);
     }
 
     public V8ValueLong(long value) {
@@ -39,6 +39,6 @@ public final class V8ValueLong extends V8ValuePrimitive<Long> {
     }
 
     public long toPrimitive() {
-        return value.longValue();
+        return value;
     }
 }

--- a/src/main/java/com/caoccao/javet/values/primitive/V8ValuePrimitive.java
+++ b/src/main/java/com/caoccao/javet/values/primitive/V8ValuePrimitive.java
@@ -20,8 +20,7 @@ package com.caoccao.javet.values.primitive;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.V8Value;
 
-@SuppressWarnings("unchecked")
-public abstract class V8ValuePrimitive<T extends Object> extends V8Value {
+public abstract class V8ValuePrimitive<T> extends V8Value {
     protected T value;
 
     public V8ValuePrimitive() {
@@ -39,7 +38,7 @@ public abstract class V8ValuePrimitive<T extends Object> extends V8Value {
 
     @Override
     public boolean equals(V8Value v8Value) {
-        if (v8Value == null || !(v8Value instanceof V8ValuePrimitive)) {
+        if (!(v8Value instanceof V8ValuePrimitive)) {
             return false;
         }
         if (v8Value.getClass() != this.getClass()) {

--- a/src/main/java/com/caoccao/javet/values/primitive/V8ValueUnknown.java
+++ b/src/main/java/com/caoccao/javet/values/primitive/V8ValueUnknown.java
@@ -18,7 +18,6 @@
 package com.caoccao.javet.values.primitive;
 
 import com.caoccao.javet.exceptions.JavetException;
-import com.caoccao.javet.values.V8Value;
 
 @SuppressWarnings("unchecked")
 public final class V8ValueUnknown extends V8ValuePrimitive<String> {

--- a/src/main/java/com/caoccao/javet/values/reference/IV8Module.java
+++ b/src/main/java/com/caoccao/javet/values/reference/IV8Module.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interop.IV8Executable;
 import com.caoccao.javet.values.V8Value;
@@ -30,13 +31,16 @@ public interface IV8Module extends IV8ValueReference, IV8Executable {
     int Evaluated = 4;
     int Errored = 5;
 
+    @CheckReturnValue
     default <T extends V8Value> T evaluate() throws JavetException {
         return evaluate(true);
     }
 
+    @CheckReturnValue
     <T extends V8Value> T evaluate(boolean resultRequired) throws JavetException;
 
     @Override
+    @CheckReturnValue
     default <T extends V8Value> T execute(boolean resultRequired) throws JavetException {
         if (getStatus() == Uninstantiated) {
             if (!instantiate()) {
@@ -44,11 +48,12 @@ public interface IV8Module extends IV8ValueReference, IV8Executable {
             }
         }
         if (getStatus() == Instantiated) {
-            return (T) evaluate(resultRequired);
+            return evaluate(resultRequired);
         }
         return (T) getV8Runtime().createV8ValueUndefined();
     }
 
+    @CheckReturnValue
     V8ValueError getException() throws JavetException;
 
     String getResourceName();
@@ -70,12 +75,13 @@ public interface IV8Module extends IV8ValueReference, IV8Executable {
     boolean instantiate() throws JavetException;
 
     @Override
-    default <T extends Object, V extends V8Value> T toObject(V v8Value) throws JavetException {
+    default <T, V extends V8Value> T toObject(V v8Value) throws JavetException {
         return getV8Runtime().toObject(v8Value);
     }
 
     @Override
-    default <T extends Object, V extends V8Value> V toV8Value(T object) throws JavetException {
+    @CheckReturnValue
+    default <T, V extends V8Value> V toV8Value(T object) throws JavetException {
         return getV8Runtime().toV8Value(object);
     }
 }

--- a/src/main/java/com/caoccao/javet/values/reference/IV8Script.java
+++ b/src/main/java/com/caoccao/javet/values/reference/IV8Script.java
@@ -17,23 +17,24 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interop.IV8Executable;
 import com.caoccao.javet.values.V8Value;
 
-@SuppressWarnings("unchecked")
 public interface IV8Script extends IV8ValueReference, IV8Executable {
     String getResourceName();
 
     void setResourceName(String resourceName);
 
     @Override
-    default <T extends Object, V extends V8Value> T toObject(V v8Value) throws JavetException {
+    default <T, V extends V8Value> T toObject(V v8Value) throws JavetException {
         return getV8Runtime().toObject(v8Value);
     }
 
     @Override
-    default <T extends Object, V extends V8Value> V toV8Value(T object) throws JavetException {
+    @CheckReturnValue
+    default <T, V extends V8Value> V toV8Value(T object) throws JavetException {
         return getV8Runtime().toV8Value(object);
     }
 }

--- a/src/main/java/com/caoccao/javet/values/reference/IV8ValueArray.java
+++ b/src/main/java/com/caoccao/javet/values/reference/IV8ValueArray.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.V8Value;
 import com.caoccao.javet.values.primitive.V8ValueNull;
@@ -27,12 +28,14 @@ import java.util.List;
 
 @SuppressWarnings("unchecked")
 public interface IV8ValueArray extends IV8ValueObject {
+    @CheckReturnValue
     <T extends V8Value> T get(int index) throws JavetException;
 
     List<Integer> getKeys() throws JavetException;
 
     int getLength() throws JavetException;
 
+    @CheckReturnValue
     <T extends V8Value> T pop() throws JavetException;
 
     default Boolean popBoolean() throws JavetException {
@@ -55,7 +58,7 @@ public interface IV8ValueArray extends IV8ValueObject {
         return pop();
     }
 
-    default <T extends Object> T popObject() throws JavetException {
+    default <T> T popObject() throws JavetException {
         try {
             return getV8Runtime().toObject(pop(), true);
         } catch (JavetException e) {
@@ -65,10 +68,12 @@ public interface IV8ValueArray extends IV8ValueObject {
         }
     }
 
-    default <R extends Object, T extends V8ValuePrimitive<R>> R popPrimitive() throws JavetException {
+    default <R, T extends V8ValuePrimitive<R>> R popPrimitive() throws JavetException {
         try (V8Value v8Value = pop()) {
             return ((T) v8Value).getValue();
-        } catch (Throwable t) {
+        } catch (JavetException e) {
+            throw e;
+        } catch (Throwable ignored) {
         }
         return null;
     }

--- a/src/main/java/com/caoccao/javet/values/reference/IV8ValueFunction.java
+++ b/src/main/java/com/caoccao/javet/values/reference/IV8ValueFunction.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.enums.JSFunctionType;
 import com.caoccao.javet.enums.JSScopeType;
 import com.caoccao.javet.exceptions.JavetException;
@@ -37,6 +38,7 @@ public interface IV8ValueFunction extends IV8ValueObject {
      * @return the V8 value
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     default <T extends V8Value> T call(IV8ValueObject receiver, Object... objects) throws JavetException {
         return callExtended(receiver, true, objects);
     }
@@ -50,6 +52,7 @@ public interface IV8ValueFunction extends IV8ValueObject {
      * @return the V8 value
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     default <T extends V8Value> T call(IV8ValueObject receiver, V8Value... v8Values) throws JavetException {
         return callExtended(receiver, true, v8Values);
     }
@@ -62,6 +65,7 @@ public interface IV8ValueFunction extends IV8ValueObject {
      * @return the V8 value
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     <T extends V8Value> T callAsConstructor(Object... objects) throws JavetException;
 
     /**
@@ -72,6 +76,7 @@ public interface IV8ValueFunction extends IV8ValueObject {
      * @return the V8 value
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     <T extends V8Value> T callAsConstructor(V8Value... v8Values) throws JavetException;
 
     /**
@@ -108,6 +113,7 @@ public interface IV8ValueFunction extends IV8ValueObject {
      * @return the t
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     <T extends V8Value> T callExtended(IV8ValueObject receiver, boolean returnResult, Object... objects)
             throws JavetException;
 
@@ -121,6 +127,7 @@ public interface IV8ValueFunction extends IV8ValueObject {
      * @return the t
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     <T extends V8Value> T callExtended(IV8ValueObject receiver, boolean returnResult, V8Value... v8Values)
             throws JavetException;
 
@@ -171,7 +178,7 @@ public interface IV8ValueFunction extends IV8ValueObject {
      * @return the object
      * @throws JavetException the javet exception
      */
-    default <T extends Object> T callObject(IV8ValueObject receiver, Object... objects) throws JavetException {
+    default <T> T callObject(IV8ValueObject receiver, Object... objects) throws JavetException {
         try {
             return getV8Runtime().toObject(callExtended(receiver, true, objects), true);
         } catch (JavetException e) {
@@ -191,10 +198,12 @@ public interface IV8ValueFunction extends IV8ValueObject {
      * @return the primitive object
      * @throws JavetException the javet exception
      */
-    default <R extends Object, T extends V8ValuePrimitive<R>> R callPrimitive(
+    default <R, T extends V8ValuePrimitive<R>> R callPrimitive(
             IV8ValueObject receiver, Object... objects) throws JavetException {
         try (V8Value v8Value = callExtended(receiver, true, objects)) {
             return ((T) v8Value).getValue();
+        } catch (JavetException e) {
+            throw e;
         } catch (Throwable t) {
             return null;
         }
@@ -219,6 +228,7 @@ public interface IV8ValueFunction extends IV8ValueObject {
      * @param objects  the objects
      * @throws JavetException the javet exception
      */
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     default void callVoid(IV8ValueObject receiver, Object... objects) throws JavetException {
         callExtended(receiver, false, objects);
     }
@@ -230,6 +240,7 @@ public interface IV8ValueFunction extends IV8ValueObject {
      * @param v8Values the V8 values
      * @throws JavetException the javet exception
      */
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     default void callVoid(IV8ValueObject receiver, V8Value... v8Values) throws JavetException {
         callExtended(receiver, false, v8Values);
     }
@@ -240,6 +251,7 @@ public interface IV8ValueFunction extends IV8ValueObject {
      * @return the internal properties
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     IV8ValueArray getInternalProperties() throws JavetException;
 
     /**

--- a/src/main/java/com/caoccao/javet/values/reference/IV8ValueIterator.java
+++ b/src/main/java/com/caoccao/javet/values/reference/IV8ValueIterator.java
@@ -25,7 +25,6 @@ import com.caoccao.javet.values.V8Value;
  *
  * @param <T> the type parameter
  */
-@SuppressWarnings("unchecked")
 public interface IV8ValueIterator<T extends V8Value> extends IJavetClosable {
     /**
      * Gets next.

--- a/src/main/java/com/caoccao/javet/values/reference/IV8ValueKeyContainer.java
+++ b/src/main/java/com/caoccao/javet/values/reference/IV8ValueKeyContainer.java
@@ -17,14 +17,12 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.V8Value;
-import com.caoccao.javet.values.primitive.*;
 
-import java.util.List;
-
-@SuppressWarnings("unchecked")
 public interface IV8ValueKeyContainer extends IV8ValueObject {
+    @CheckReturnValue
     IV8ValueIterator<? extends V8Value> getKeys() throws JavetException;
 
     int getSize() throws JavetException;

--- a/src/main/java/com/caoccao/javet/values/reference/IV8ValueMap.java
+++ b/src/main/java/com/caoccao/javet/values/reference/IV8ValueMap.java
@@ -17,14 +17,14 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.V8Value;
 
-import java.util.List;
-
-@SuppressWarnings("unchecked")
 public interface IV8ValueMap extends IV8ValueKeyContainer {
+    @CheckReturnValue
     IV8ValueIterator<V8ValueArray> getEntries() throws JavetException;
 
+    @CheckReturnValue
     IV8ValueIterator<? extends V8Value> getValues() throws JavetException;
 }

--- a/src/main/java/com/caoccao/javet/values/reference/IV8ValueObject.java
+++ b/src/main/java/com/caoccao/javet/values/reference/IV8ValueObject.java
@@ -19,7 +19,9 @@ package com.caoccao.javet.values.reference;
 
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interfaces.IJavetBiConsumer;
-import com.caoccao.javet.interfaces.IJavetConsumer;
+import com.caoccao.javet.interfaces.IJavetBiIndexedConsumer;
+import com.caoccao.javet.interfaces.IJavetUniConsumer;
+import com.caoccao.javet.interfaces.IJavetUniIndexedConsumer;
 import com.caoccao.javet.utils.JavetCallbackContext;
 import com.caoccao.javet.values.V8Value;
 import com.caoccao.javet.values.primitive.V8ValueNull;
@@ -206,7 +208,21 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @throws JavetException the javet exception
      * @throws E              the exception
      */
-    <Key extends V8Value, E extends Throwable> int forEach(IJavetConsumer<Key, E> consumer) throws JavetException, E;
+    <Key extends V8Value, E extends Throwable> int forEach(
+            IJavetUniConsumer<Key, E> consumer) throws JavetException, E;
+
+    /**
+     * For each.
+     *
+     * @param <Key>    the type of key
+     * @param <E>      the type of exception
+     * @param consumer the consumer
+     * @return the item count
+     * @throws JavetException the javet exception
+     * @throws E              the exception
+     */
+    <Key extends V8Value, E extends Throwable> int forEach(
+            IJavetUniIndexedConsumer<Key, E> consumer) throws JavetException, E;
 
     /**
      * For each.
@@ -221,6 +237,20 @@ public interface IV8ValueObject extends IV8ValueReference {
      */
     <Key extends V8Value, Value extends V8Value, E extends Throwable> int forEach(
             IJavetBiConsumer<Key, Value, E> consumer) throws JavetException, E;
+
+    /**
+     * For each.
+     *
+     * @param <Key>    the type of key
+     * @param <Value>  the type of value
+     * @param <E>      the type of exception
+     * @param consumer the consumer
+     * @return the item count
+     * @throws JavetException the javet exception
+     * @throws E              the exception
+     */
+    <Key extends V8Value, Value extends V8Value, E extends Throwable> int forEach(
+            IJavetBiIndexedConsumer<Key, Value, E> consumer) throws JavetException, E;
 
     /**
      * Get t.

--- a/src/main/java/com/caoccao/javet/values/reference/IV8ValueObject.java
+++ b/src/main/java/com/caoccao/javet/values/reference/IV8ValueObject.java
@@ -29,7 +29,6 @@ import com.caoccao.javet.values.primitive.V8ValuePrimitive;
 import com.caoccao.javet.values.primitive.V8ValueUndefined;
 
 import java.time.ZonedDateTime;
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -38,32 +37,27 @@ import java.util.List;
 @SuppressWarnings("unchecked")
 public interface IV8ValueObject extends IV8ValueReference {
     /**
-     * Bind both functions and properties.
+     * Bind both functions via @V8Function and properties via @V8Property.
      *
      * @param callbackReceiver the callback receiver
      * @return the list of callback context
      * @throws JavetException the javet exception
+     * @since 0.8.9
      */
-    default List<JavetCallbackContext> bind(Object callbackReceiver)
-            throws JavetException {
+    default List<JavetCallbackContext> bind(Object callbackReceiver) throws JavetException {
         return bind(callbackReceiver, false);
     }
 
     /**
-     * Bind both functions and properties.
+     * Bind both functions via @V8Function and properties via @V8Property.
      *
      * @param callbackReceiver   the callback receiver
      * @param thisObjectRequired the this object required
      * @return the list of callback context
      * @throws JavetException the javet exception
+     * @since 0.8.9
      */
-    default List<JavetCallbackContext> bind(Object callbackReceiver, boolean thisObjectRequired)
-            throws JavetException {
-        List<JavetCallbackContext> javetCallbackContexts = new ArrayList<>();
-        javetCallbackContexts.addAll(bindProperties(callbackReceiver));
-        javetCallbackContexts.addAll(bindFunctions(callbackReceiver, thisObjectRequired));
-        return javetCallbackContexts;
-    }
+    List<JavetCallbackContext> bind(Object callbackReceiver, boolean thisObjectRequired) throws JavetException;
 
     /**
      * Binds function by name and callback context.
@@ -76,11 +70,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @throws JavetException the javet exception
      * @since 0.8.9
      */
-    default boolean bindFunction(String functionName, JavetCallbackContext javetCallbackContext) throws JavetException {
-        try (V8ValueFunction v8ValueFunction = getV8Runtime().createV8ValueFunction(javetCallbackContext)) {
-            return set(functionName, v8ValueFunction);
-        }
-    }
+    boolean bindFunction(String functionName, JavetCallbackContext javetCallbackContext) throws JavetException;
 
     /**
      * Binds function by name and string.
@@ -98,11 +88,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @throws JavetException the javet exception
      * @since 0.8.9
      */
-    default boolean bindFunction(String functionName, String codeString) throws JavetException {
-        try (V8ValueFunction v8ValueFunction = getV8Runtime().getExecutor(codeString).execute()) {
-            return set(functionName, v8ValueFunction);
-        }
-    }
+    boolean bindFunction(String functionName, String codeString) throws JavetException;
 
     /**
      * Binds functions.
@@ -112,6 +98,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @throws JavetException the javet exception
      * @since 0.8.9
      */
+    @Deprecated
     default List<JavetCallbackContext> bindFunctions(Object functionCallbackReceiver) throws JavetException {
         return bindFunctions(functionCallbackReceiver, false);
     }
@@ -125,8 +112,11 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @throws JavetException the javet exception
      * @since 0.8.9
      */
-    List<JavetCallbackContext> bindFunctions(Object functionCallbackReceiver, boolean thisObjectRequired)
-            throws JavetException;
+    @Deprecated
+    default List<JavetCallbackContext> bindFunctions(Object functionCallbackReceiver, boolean thisObjectRequired)
+            throws JavetException {
+        return bind(functionCallbackReceiver, thisObjectRequired);
+    }
 
     /**
      * Bind properties via annotation @V8Property.
@@ -139,7 +129,10 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the list of callback context
      * @throws JavetException the javet exception
      */
-    List<JavetCallbackContext> bindProperties(Object propertyCallbackReceiver) throws JavetException;
+    @Deprecated
+    default List<JavetCallbackContext> bindProperties(Object propertyCallbackReceiver) throws JavetException {
+        return bind(propertyCallbackReceiver, false);
+    }
 
     /**
      * Bind property.

--- a/src/main/java/com/caoccao/javet/values/reference/IV8ValueObject.java
+++ b/src/main/java/com/caoccao/javet/values/reference/IV8ValueObject.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interfaces.IJavetBiConsumer;
 import com.caoccao.javet.interfaces.IJavetBiIndexedConsumer;
@@ -253,6 +254,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the t
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     <T extends V8Value> T get(Object key) throws JavetException;
 
     /**
@@ -342,7 +344,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the object
      * @throws JavetException the javet exception
      */
-    default <T extends Object> T getObject(Object key) throws JavetException {
+    default <T> T getObject(Object key) throws JavetException {
         try {
             return getV8Runtime().toObject(get(key), true);
         } catch (JavetException e) {
@@ -358,6 +360,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the own property names
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     IV8ValueArray getOwnPropertyNames() throws JavetException;
 
     /**
@@ -369,11 +372,12 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the primitive
      * @throws JavetException the javet exception
      */
-    default <R extends Object, T extends V8ValuePrimitive<R>> R getPrimitive(Object key)
-            throws JavetException {
+    default <R, T extends V8ValuePrimitive<R>> R getPrimitive(Object key) throws JavetException {
         try (V8Value v8Value = get(key)) {
             return ((T) v8Value).getValue();
-        } catch (Throwable t) {
+        } catch (JavetException e) {
+            throw e;
+        } catch (Throwable ignored) {
         }
         return null;
     }
@@ -386,6 +390,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the property
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     <T extends V8Value> T getProperty(Object key) throws JavetException;
 
     /**
@@ -393,9 +398,8 @@ public interface IV8ValueObject extends IV8ValueReference {
      *
      * @param key the key
      * @return the property boolean
-     * @throws JavetException the javet exception
      */
-    default Boolean getPropertyBoolean(Object key) throws JavetException {
+    default Boolean getPropertyBoolean(Object key) {
         return getPropertyPrimitive(key);
     }
 
@@ -404,9 +408,8 @@ public interface IV8ValueObject extends IV8ValueReference {
      *
      * @param key the key
      * @return the property double
-     * @throws JavetException the javet exception
      */
-    default Double getPropertyDouble(Object key) throws JavetException {
+    default Double getPropertyDouble(Object key) {
         return getPropertyPrimitive(key);
     }
 
@@ -415,9 +418,8 @@ public interface IV8ValueObject extends IV8ValueReference {
      *
      * @param key the key
      * @return the property float
-     * @throws JavetException the javet exception
      */
-    default Float getPropertyFloat(Object key) throws JavetException {
+    default Float getPropertyFloat(Object key) {
         Double result = getPropertyDouble(key);
         return result == null ? null : result.floatValue();
     }
@@ -427,9 +429,8 @@ public interface IV8ValueObject extends IV8ValueReference {
      *
      * @param key the key
      * @return the property integer
-     * @throws JavetException the javet exception
      */
-    default Integer getPropertyInteger(Object key) throws JavetException {
+    default Integer getPropertyInteger(Object key) {
         return getPropertyPrimitive(key);
     }
 
@@ -438,9 +439,8 @@ public interface IV8ValueObject extends IV8ValueReference {
      *
      * @param key the key
      * @return the property long
-     * @throws JavetException the javet exception
      */
-    default Long getPropertyLong(Object key) throws JavetException {
+    default Long getPropertyLong(Object key) {
         return getPropertyPrimitive(key);
     }
 
@@ -460,7 +460,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the property object
      * @throws JavetException the javet exception
      */
-    default <T extends Object> T getPropertyObject(Object key) throws JavetException {
+    default <T> T getPropertyObject(Object key) throws JavetException {
         try {
             return getV8Runtime().toObject(getProperty(key), true);
         } catch (JavetException e) {
@@ -477,13 +477,11 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @param <T> the type parameter
      * @param key the key
      * @return the property primitive
-     * @throws JavetException the javet exception
      */
-    default <R extends Object, T extends V8ValuePrimitive<R>> R getPropertyPrimitive(Object key)
-            throws JavetException {
+    default <R, T extends V8ValuePrimitive<R>> R getPropertyPrimitive(Object key) {
         try (V8Value v8Value = getProperty(key)) {
             return ((T) v8Value).getValue();
-        } catch (Throwable t) {
+        } catch (Throwable ignored) {
         }
         return null;
     }
@@ -493,9 +491,8 @@ public interface IV8ValueObject extends IV8ValueReference {
      *
      * @param key the key
      * @return the property string
-     * @throws JavetException the javet exception
      */
-    default String getPropertyString(Object key) throws JavetException {
+    default String getPropertyString(Object key) {
         return getPropertyPrimitive(key);
     }
 
@@ -504,9 +501,8 @@ public interface IV8ValueObject extends IV8ValueReference {
      *
      * @param key the key
      * @return the property zoned date time
-     * @throws JavetException the javet exception
      */
-    default ZonedDateTime getPropertyZonedDateTime(Object key) throws JavetException {
+    default ZonedDateTime getPropertyZonedDateTime(Object key) {
         return getPropertyPrimitive(key);
     }
 
@@ -590,6 +586,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the t
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     default <T extends V8Value> T invoke(String functionName, Object... objects) throws JavetException {
         return invokeExtended(functionName, true, objects);
     }
@@ -603,6 +600,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the t
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     default <T extends V8Value> T invoke(String functionName, V8Value... v8Values) throws JavetException {
         return invokeExtended(functionName, true, v8Values);
     }
@@ -613,14 +611,14 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @param functionName the function name
      * @param objects      the objects
      * @return the boolean
-     * @throws JavetException the javet exception
      */
-    default Boolean invokeBoolean(String functionName, Object... objects) throws JavetException {
+    default Boolean invokeBoolean(String functionName, Object... objects) {
         return invokePrimitive(functionName, objects);
     }
 
     /**
-     * Invoke extended t.
+     * Invoke extended and return V8 value which must be consumed,
+     * otherwise memory leak may occur.
      *
      * @param <T>          the type parameter
      * @param functionName the function name
@@ -629,10 +627,12 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the t
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     <T extends V8Value> T invokeExtended(String functionName, boolean returnResult, Object... objects) throws JavetException;
 
     /**
-     * Invoke extended t.
+     * Invoke extended and return V8 value which must be consumed,
+     * otherwise memory leak may occur.
      *
      * @param <T>          the type parameter
      * @param functionName the function name
@@ -641,6 +641,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the t
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     <T extends V8Value> T invokeExtended(String functionName, boolean returnResult, V8Value... v8Values) throws JavetException;
 
     /**
@@ -649,9 +650,8 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @param functionName the function name
      * @param objects      the objects
      * @return the double
-     * @throws JavetException the javet exception
      */
-    default Double invokeDouble(String functionName, Object... objects) throws JavetException {
+    default Double invokeDouble(String functionName, Object... objects) {
         return invokePrimitive(functionName, objects);
     }
 
@@ -661,9 +661,8 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @param functionName the function name
      * @param objects      the objects
      * @return the float
-     * @throws JavetException the javet exception
      */
-    default Float invokeFloat(String functionName, Object... objects) throws JavetException {
+    default Float invokeFloat(String functionName, Object... objects) {
         Double result = invokeDouble(functionName, objects);
         return result == null ? null : result.floatValue();
     }
@@ -674,9 +673,8 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @param functionName the function name
      * @param objects      the objects
      * @return the integer
-     * @throws JavetException the javet exception
      */
-    default Integer invokeInteger(String functionName, Object... objects) throws JavetException {
+    default Integer invokeInteger(String functionName, Object... objects) {
         return invokePrimitive(functionName, objects);
     }
 
@@ -686,9 +684,8 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @param functionName the function name
      * @param objects      the objects
      * @return the long
-     * @throws JavetException the javet exception
      */
-    default Long invokeLong(String functionName, Object... objects) throws JavetException {
+    default Long invokeLong(String functionName, Object... objects) {
         return invokePrimitive(functionName, objects);
     }
 
@@ -701,7 +698,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the t
      * @throws JavetException the javet exception
      */
-    default <T extends Object> T invokeObject(String functionName, Object... objects) throws JavetException {
+    default <T> T invokeObject(String functionName, Object... objects) throws JavetException {
         try {
             return getV8Runtime().toObject(invokeExtended(functionName, true, objects), true);
         } catch (JavetException e) {
@@ -718,11 +715,10 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @param <T>          the type parameter
      * @param functionName the function name
      * @param objects      the objects
-     * @return the r
-     * @throws JavetException the javet exception
+     * @return the primitive value
      */
-    default <R extends Object, T extends V8ValuePrimitive<R>> R invokePrimitive(
-            String functionName, Object... objects) throws JavetException {
+    default <R, T extends V8ValuePrimitive<R>> R invokePrimitive(
+            String functionName, Object... objects) {
         try (V8Value v8Value = invokeExtended(functionName, true, objects)) {
             return ((T) v8Value).getValue();
         } catch (Throwable t) {
@@ -736,9 +732,8 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @param functionName the function name
      * @param objects      the objects
      * @return the string
-     * @throws JavetException the javet exception
      */
-    default String invokeString(String functionName, Object... objects) throws JavetException {
+    default String invokeString(String functionName, Object... objects) {
         return invokePrimitive(functionName, objects);
     }
 
@@ -749,6 +744,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @param objects      the objects
      * @throws JavetException the javet exception
      */
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     default void invokeVoid(String functionName, Object... objects) throws JavetException {
         invokeExtended(functionName, false, objects);
     }
@@ -760,6 +756,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @param v8Values     the v 8 values
      * @throws JavetException the javet exception
      */
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     default void invokeVoid(String functionName, V8Value... v8Values) throws JavetException {
         invokeExtended(functionName, false, v8Values);
     }
@@ -853,6 +850,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the null
      * @throws JavetException the javet exception
      */
+    @SuppressWarnings("UnusedReturnValue")
     default boolean setNull(Object key) throws JavetException {
         return set(key, getV8Runtime().createV8ValueNull());
     }
@@ -896,6 +894,7 @@ public interface IV8ValueObject extends IV8ValueReference {
      * @return the undefined
      * @throws JavetException the javet exception
      */
+    @SuppressWarnings("UnusedReturnValue")
     default boolean setUndefined(Object key) throws JavetException {
         return set(key, getV8Runtime().createV8ValueUndefined());
     }

--- a/src/main/java/com/caoccao/javet/values/reference/IV8ValuePromise.java
+++ b/src/main/java/com/caoccao/javet/values/reference/IV8ValuePromise.java
@@ -17,9 +17,8 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
-import com.caoccao.javet.interop.V8Runtime;
-import com.caoccao.javet.interop.converters.IJavetConverter;
 import com.caoccao.javet.values.V8Value;
 import com.caoccao.javet.values.primitive.V8ValuePrimitive;
 
@@ -32,8 +31,10 @@ public interface IV8ValuePromise extends IV8ValueObject {
     int STATE_FULFILLED = 1;
     int STATE_REJECTED = 2;
 
+    @CheckReturnValue
     V8ValuePromise except(V8ValueFunction function) throws JavetException;
 
+    @CheckReturnValue
     default V8ValuePromise except(String codeString) throws JavetException {
         Objects.requireNonNull(codeString);
         try (V8ValueFunction v8ValueFunction = getV8Runtime().getExecutor(codeString).execute()) {
@@ -41,6 +42,7 @@ public interface IV8ValuePromise extends IV8ValueObject {
         }
     }
 
+    @CheckReturnValue
     <Value extends V8Value> Value getResult() throws JavetException;
 
     default boolean getResultBoolean() throws JavetException {
@@ -59,7 +61,7 @@ public interface IV8ValuePromise extends IV8ValueObject {
         return getResultPrimitive();
     }
 
-    default <T extends Object> T getResultObject(Object key) throws JavetException {
+    default <T> T getResultObject(Object key) throws JavetException {
         try {
             return getV8Runtime().toObject(getResult(), true);
         } catch (JavetException e) {
@@ -69,12 +71,12 @@ public interface IV8ValuePromise extends IV8ValueObject {
         }
     }
 
-    default <R extends Object, T extends V8ValuePrimitive<R>> R getResultPrimitive()
+    default <R, T extends V8ValuePrimitive<R>> R getResultPrimitive()
             throws JavetException {
         V8Value v8Value = getResult();
         try {
             return ((T) v8Value).getValue();
-        } catch (Throwable t) {
+        } catch (Throwable ignored) {
         }
         return null;
     }
@@ -105,16 +107,20 @@ public interface IV8ValuePromise extends IV8ValueObject {
 
     void markAsHandled() throws JavetException;
 
+    @CheckReturnValue
     default V8ValuePromise then(IV8ValueFunction functionFulfilled) throws JavetException {
         return then(functionFulfilled, null);
     }
 
+    @CheckReturnValue
     V8ValuePromise then(IV8ValueFunction functionFulfilled, IV8ValueFunction functionRejected) throws JavetException;
 
+    @CheckReturnValue
     default V8ValuePromise then(String codeStringFulfilled) throws JavetException {
         return then(codeStringFulfilled, null);
     }
 
+    @CheckReturnValue
     default V8ValuePromise then(String codeStringFulfilled, String codeStringRejected) throws JavetException {
         Objects.requireNonNull(codeStringFulfilled);
         try (V8ValueFunction v8ValueFunctionFulfilled = getV8Runtime().getExecutor(codeStringFulfilled).execute()) {

--- a/src/main/java/com/caoccao/javet/values/reference/IV8ValueSet.java
+++ b/src/main/java/com/caoccao/javet/values/reference/IV8ValueSet.java
@@ -17,9 +17,9 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 
-@SuppressWarnings("unchecked")
 public interface IV8ValueSet extends IV8ValueKeyContainer {
     void add(Object key) throws JavetException;
 
@@ -31,5 +31,6 @@ public interface IV8ValueSet extends IV8ValueKeyContainer {
         add(getV8Runtime().createV8ValueUndefined());
     }
 
+    @CheckReturnValue
     IV8ValueIterator<V8ValueArray> getEntries() throws JavetException;
 }

--- a/src/main/java/com/caoccao/javet/values/reference/IV8ValueTypedArray.java
+++ b/src/main/java/com/caoccao/javet/values/reference/IV8ValueTypedArray.java
@@ -17,9 +17,11 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 
 public interface IV8ValueTypedArray extends IV8ValueObject {
+    @CheckReturnValue
     V8ValueArrayBuffer getBuffer() throws JavetException;
 
     int getByteLength() throws JavetException;

--- a/src/main/java/com/caoccao/javet/values/reference/V8Module.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8Module.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.V8Value;
@@ -33,12 +34,14 @@ public class V8Module extends V8ValueReference implements IV8Module {
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T evaluate(boolean resultRequired) throws JavetException {
         checkV8Runtime();
         return v8Runtime.moduleEvaluate(this, resultRequired);
     }
 
     @Override
+    @CheckReturnValue
     public V8ValueError getException() throws JavetException {
         checkV8Runtime();
         return v8Runtime.moduleGetException(this);
@@ -53,6 +56,7 @@ public class V8Module extends V8ValueReference implements IV8Module {
      * @return the namespace
      * @throws JavetException the javet exception
      */
+    @CheckReturnValue
     public V8ValueObject getNamespace() throws JavetException {
         checkV8Runtime();
         return v8Runtime.moduleGetNamespace(this);
@@ -91,6 +95,7 @@ public class V8Module extends V8ValueReference implements IV8Module {
     }
 
     @Override
+    @CheckReturnValue
     public V8Module toClone() throws JavetException {
         return this;
     }

--- a/src/main/java/com/caoccao/javet/values/reference/V8Script.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8Script.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.V8Value;
 import com.caoccao.javet.enums.V8ValueReferenceType;
@@ -33,6 +34,7 @@ public class V8Script extends V8ValueReference implements IV8Script {
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T execute(boolean resultRequired) throws JavetException {
         checkV8Runtime();
         return v8Runtime.scriptRun(this, resultRequired);

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueArray.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueArray.java
@@ -19,7 +19,8 @@ package com.caoccao.javet.values.reference;
 
 import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.exceptions.JavetException;
-import com.caoccao.javet.interfaces.IJavetConsumer;
+import com.caoccao.javet.interfaces.IJavetUniConsumer;
+import com.caoccao.javet.interfaces.IJavetUniIndexedConsumer;
 import com.caoccao.javet.values.V8Value;
 
 import java.util.ArrayList;
@@ -41,12 +42,24 @@ public class V8ValueArray extends V8ValueObject implements IV8ValueArray {
 
     @Override
     public <Value extends V8Value, E extends Throwable> int forEach(
-            IJavetConsumer<Value, E> consumer) throws JavetException, E {
+            IJavetUniConsumer<Value, E> consumer) throws JavetException, E {
         Objects.requireNonNull(consumer);
         final int length = getLength();
         for (int i = 0; i < length; ++i) {
             try (Value value = get(i)) {
                 consumer.accept(value);
+            }
+        }
+        return length;
+    }
+
+    @Override
+    public <Value extends V8Value, E extends Throwable> int forEach(IJavetUniIndexedConsumer<Value, E> consumer) throws JavetException, E {
+        Objects.requireNonNull(consumer);
+        final int length = getLength();
+        for (int i = 0; i < length; ++i) {
+            try (Value value = get(i)) {
+                consumer.accept(i, value);
             }
         }
         return length;

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueArray.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueArray.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interfaces.IJavetUniConsumer;
@@ -27,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-@SuppressWarnings("unchecked")
 public class V8ValueArray extends V8ValueObject implements IV8ValueArray {
     protected static final String FUNCTION_NEXT = "next";
     protected static final String FUNCTION_KEYS = "keys";
@@ -54,7 +54,8 @@ public class V8ValueArray extends V8ValueObject implements IV8ValueArray {
     }
 
     @Override
-    public <Value extends V8Value, E extends Throwable> int forEach(IJavetUniIndexedConsumer<Value, E> consumer) throws JavetException, E {
+    public <Value extends V8Value, E extends Throwable> int forEach(
+            IJavetUniIndexedConsumer<Value, E> consumer) throws JavetException, E {
         Objects.requireNonNull(consumer);
         final int length = getLength();
         for (int i = 0; i < length; ++i) {
@@ -66,6 +67,7 @@ public class V8ValueArray extends V8ValueObject implements IV8ValueArray {
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T get(int index) throws JavetException {
         checkV8Runtime();
         return v8Runtime.get(this, v8Runtime.createV8ValueInteger(index));
@@ -100,6 +102,7 @@ public class V8ValueArray extends V8ValueObject implements IV8ValueArray {
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T pop() throws JavetException {
         checkV8Runtime();
         return invoke(FUNCTION_POP);

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueArrayBuffer.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueArrayBuffer.java
@@ -24,7 +24,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Objects;
 
-@SuppressWarnings("unchecked")
 public class V8ValueArrayBuffer extends V8ValueObject {
     protected static final String PROPERTY_BYTE_LENGTH = "byteLength";
     protected static final int BYTE_LENGTH_1 = 1;
@@ -63,7 +62,6 @@ public class V8ValueArrayBuffer extends V8ValueObject {
     }
 
     public boolean fromBytes(byte[] bytes) {
-        Objects.requireNonNull(bytes);
         if (bytes != null && bytes.length > 0 && bytes.length == byteBuffer.capacity()) {
             byteBuffer.put(bytes);
             return true;
@@ -72,7 +70,6 @@ public class V8ValueArrayBuffer extends V8ValueObject {
     }
 
     public boolean fromDoubles(double[] doubles) {
-        Objects.requireNonNull(doubles);
         if (doubles != null && doubles.length > 0 && doubles.length == byteBuffer.capacity() >> BYTE_LENGTH_3) {
             byteBuffer.order(byteOrder).asDoubleBuffer().put(doubles);
             return true;
@@ -81,7 +78,6 @@ public class V8ValueArrayBuffer extends V8ValueObject {
     }
 
     public boolean fromFloats(float[] floats) {
-        Objects.requireNonNull(floats);
         if (floats != null && floats.length > 0 && floats.length == byteBuffer.capacity() >> BYTE_LENGTH_2) {
             byteBuffer.order(byteOrder).asFloatBuffer().put(floats);
             return true;
@@ -90,7 +86,6 @@ public class V8ValueArrayBuffer extends V8ValueObject {
     }
 
     public boolean fromIntegers(int[] integers) {
-        Objects.requireNonNull(integers);
         if (integers != null && integers.length > 0 && integers.length == byteBuffer.capacity() >> BYTE_LENGTH_2) {
             byteBuffer.order(byteOrder).asIntBuffer().put(integers);
             return true;
@@ -99,7 +94,6 @@ public class V8ValueArrayBuffer extends V8ValueObject {
     }
 
     public boolean fromLongs(long[] longs) {
-        Objects.requireNonNull(longs);
         if (longs != null && longs.length > 0 && longs.length == byteBuffer.capacity() >> BYTE_LENGTH_3) {
             byteBuffer.order(byteOrder).asLongBuffer().put(longs);
             return true;
@@ -108,7 +102,6 @@ public class V8ValueArrayBuffer extends V8ValueObject {
     }
 
     public boolean fromShorts(short[] shorts) {
-        Objects.requireNonNull(shorts);
         if (shorts != null && shorts.length > 0 && shorts.length == byteBuffer.capacity() >> BYTE_LENGTH_1) {
             byteBuffer.order(byteOrder).asShortBuffer().put(shorts);
             return true;

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueDataView.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueDataView.java
@@ -50,12 +50,12 @@ public class V8ValueDataView extends V8ValueObject {
         super(handle);
     }
 
-    public long getBigInt64(int byteOffset) throws JavetException {
+    public long getBigInt64(int byteOffset) {
         return getBigInt64(byteOffset, true);
     }
 
-    public long getBigInt64(int byteOffset, boolean littleEndian) throws JavetException {
-        return invokeLong(FUNCTION_GET_BIG_INT_64, byteOffset, littleEndian).longValue();
+    public long getBigInt64(int byteOffset, boolean littleEndian) {
+        return invokeLong(FUNCTION_GET_BIG_INT_64, byteOffset, littleEndian);
     }
 
     public V8ValueArrayBuffer getBuffer() throws JavetException {
@@ -70,39 +70,39 @@ public class V8ValueDataView extends V8ValueObject {
         return getInteger(PROPERTY_BYTE_OFFSET);
     }
 
-    public float getFloat32(int byteOffset) throws JavetException {
+    public float getFloat32(int byteOffset) {
         return getFloat32(byteOffset, true);
     }
 
-    public float getFloat32(int byteOffset, boolean littleEndian) throws JavetException {
+    public float getFloat32(int byteOffset, boolean littleEndian) {
         return invokeDouble(FUNCTION_GET_FLOAT_32, byteOffset, littleEndian).floatValue();
     }
 
-    public double getFloat64(int byteOffset) throws JavetException {
+    public double getFloat64(int byteOffset) {
         return getFloat64(byteOffset, true);
     }
 
-    public double getFloat64(int byteOffset, boolean littleEndian) throws JavetException {
-        return invokeDouble(FUNCTION_GET_FLOAT_64, byteOffset, littleEndian).doubleValue();
+    public double getFloat64(int byteOffset, boolean littleEndian) {
+        return invokeDouble(FUNCTION_GET_FLOAT_64, byteOffset, littleEndian);
     }
 
-    public short getInt16(int byteOffset) throws JavetException {
+    public short getInt16(int byteOffset) {
         return getInt16(byteOffset, true);
     }
 
-    public short getInt16(int byteOffset, boolean littleEndian) throws JavetException {
+    public short getInt16(int byteOffset, boolean littleEndian) {
         return invokeInteger(FUNCTION_GET_INT_16, byteOffset, littleEndian).shortValue();
     }
 
-    public int getInt32(int byteOffset) throws JavetException {
+    public int getInt32(int byteOffset) {
         return getInt32(byteOffset, true);
     }
 
-    public int getInt32(int byteOffset, boolean littleEndian) throws JavetException {
-        return invokeInteger(FUNCTION_GET_INT_32, byteOffset, littleEndian).intValue();
+    public int getInt32(int byteOffset, boolean littleEndian) {
+        return invokeInteger(FUNCTION_GET_INT_32, byteOffset, littleEndian);
     }
 
-    public byte getInt8(int byteOffset) throws JavetException {
+    public byte getInt8(int byteOffset) {
         return invokeInteger(FUNCTION_GET_INT_8, byteOffset).byteValue();
     }
 

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueFunction.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueFunction.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.enums.JSFunctionType;
 import com.caoccao.javet.enums.JSScopeType;
 import com.caoccao.javet.enums.V8ValueReferenceType;
@@ -26,7 +27,6 @@ import com.caoccao.javet.values.virtual.V8VirtualValueList;
 
 import java.util.Optional;
 
-@SuppressWarnings("unchecked")
 public class V8ValueFunction extends V8ValueObject implements IV8ValueFunction {
     protected Optional<JSFunctionType> jsFunctionType;
 
@@ -36,6 +36,7 @@ public class V8ValueFunction extends V8ValueObject implements IV8ValueFunction {
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T callExtended(IV8ValueObject receiver, boolean returnResult, Object... objects)
             throws JavetException {
         checkV8Runtime();
@@ -45,6 +46,7 @@ public class V8ValueFunction extends V8ValueObject implements IV8ValueFunction {
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T callExtended(IV8ValueObject receiver, boolean returnResult, V8Value... v8Values) throws JavetException {
         checkV8Runtime();
         v8Runtime.decorateV8Values(v8Values);
@@ -52,6 +54,7 @@ public class V8ValueFunction extends V8ValueObject implements IV8ValueFunction {
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T callAsConstructor(Object... objects) throws JavetException {
         checkV8Runtime();
         try (V8VirtualValueList virtualValueList = new V8VirtualValueList(v8Runtime, objects)) {
@@ -60,6 +63,7 @@ public class V8ValueFunction extends V8ValueObject implements IV8ValueFunction {
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T callAsConstructor(V8Value... v8Values) throws JavetException {
         checkV8Runtime();
         v8Runtime.decorateV8Values(v8Values);
@@ -72,6 +76,7 @@ public class V8ValueFunction extends V8ValueObject implements IV8ValueFunction {
     }
 
     @Override
+    @CheckReturnValue
     public IV8ValueArray getInternalProperties() throws JavetException {
         checkV8Runtime();
         return v8Runtime.getInternalProperties(this);

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueGlobalObject.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueGlobalObject.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.reference.builtin.V8ValueBuiltInJson;
 import com.caoccao.javet.values.reference.builtin.V8ValueBuiltInPromise;
@@ -49,7 +50,8 @@ public final class V8ValueGlobalObject extends V8ValueObject {
     }
 
     @Override
-    public void clearWeak() throws JavetException {
+    public void clearWeak() {
+        // Global object is persisted.
     }
 
     @Override
@@ -57,18 +59,20 @@ public final class V8ValueGlobalObject extends V8ValueObject {
         // Global object lives as long as V8 runtime lives.
     }
 
+    @CheckReturnValue
     public V8ValueBuiltInJson getJson() throws JavetException {
         V8ValueObject v8ValueObject = get(PROPERTY_JSON);
         return v8Runtime.decorateV8Value(new V8ValueBuiltInJson(v8ValueObject.getHandle()));
     }
 
+    @CheckReturnValue
     public V8ValueBuiltInPromise getPromise() throws JavetException {
         V8ValueObject v8ValueObject = get(PROPERTY_PROMISE);
         return v8Runtime.decorateV8Value(new V8ValueBuiltInPromise(v8ValueObject.getHandle()));
     }
 
     @Override
-    public boolean isWeak() throws JavetException {
+    public boolean isWeak() {
         return false;
     }
 
@@ -78,7 +82,8 @@ public final class V8ValueGlobalObject extends V8ValueObject {
     }
 
     @Override
-    public void setWeak() throws JavetException {
+    public void setWeak() {
+        // Global object is persisted.
     }
 
     @Override

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueIterator.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueIterator.java
@@ -17,11 +17,11 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.V8Value;
 import com.caoccao.javet.enums.V8ValueReferenceType;
 
-@SuppressWarnings("unchecked")
 public class V8ValueIterator<T extends V8Value> extends V8ValueObject implements IV8ValueIterator<T> {
     protected static final String FUNCTION_NEXT = "next";
     protected static final String PROPERTY_DONE = "done";
@@ -37,12 +37,13 @@ public class V8ValueIterator<T extends V8Value> extends V8ValueObject implements
     }
 
     @Override
+    @CheckReturnValue
     public T getNext() {
         try (V8ValueObject next = invoke(FUNCTION_NEXT)) {
             if (!next.getBoolean(PROPERTY_DONE)) {
                 return next.get(PROPERTY_VALUE);
             }
-        } catch (JavetException javetException) {
+        } catch (JavetException ignored) {
         }
         return null;
     }

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueMap.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueMap.java
@@ -20,7 +20,9 @@ package com.caoccao.javet.values.reference;
 import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interfaces.IJavetBiConsumer;
-import com.caoccao.javet.interfaces.IJavetConsumer;
+import com.caoccao.javet.interfaces.IJavetBiIndexedConsumer;
+import com.caoccao.javet.interfaces.IJavetUniConsumer;
+import com.caoccao.javet.interfaces.IJavetUniIndexedConsumer;
 import com.caoccao.javet.values.V8Value;
 
 import java.util.Objects;
@@ -37,7 +39,7 @@ public class V8ValueMap extends V8ValueObject implements IV8ValueMap {
 
     @Override
     public <Key extends V8Value, E extends Throwable> int forEach(
-            IJavetConsumer<Key, E> consumer) throws JavetException, E {
+            IJavetUniConsumer<Key, E> consumer) throws JavetException, E {
         Objects.requireNonNull(consumer);
         int count = 0;
         try (IV8ValueIterator<Key> iterator = (IV8ValueIterator<Key>) getKeys()) {
@@ -47,6 +49,25 @@ public class V8ValueMap extends V8ValueObject implements IV8ValueMap {
                         break;
                     }
                     consumer.accept(key);
+                }
+                count++;
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public <Key extends V8Value, E extends Throwable> int forEach(
+            IJavetUniIndexedConsumer<Key, E> consumer) throws JavetException, E {
+        Objects.requireNonNull(consumer);
+        int count = 0;
+        try (IV8ValueIterator<Key> iterator = (IV8ValueIterator<Key>) getKeys()) {
+            while (true) {
+                try (Key key = iterator.getNext()) {
+                    if (key == null) {
+                        break;
+                    }
+                    consumer.accept(count, key);
                 }
                 count++;
             }
@@ -67,6 +88,27 @@ public class V8ValueMap extends V8ValueObject implements IV8ValueMap {
                     }
                     try (Key key = entry.get(0); Value value = entry.get(1);) {
                         consumer.accept(key, value);
+                    }
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public <Key extends V8Value, Value extends V8Value, E extends Throwable> int forEach(
+            IJavetBiIndexedConsumer<Key, Value, E> consumer) throws JavetException, E {
+        Objects.requireNonNull(consumer);
+        int count = 0;
+        try (IV8ValueIterator<V8ValueArray> iterator = getEntries()) {
+            while (true) {
+                try (V8ValueArray entry = iterator.getNext()) {
+                    if (entry == null) {
+                        break;
+                    }
+                    try (Key key = entry.get(0); Value value = entry.get(1);) {
+                        consumer.accept(count, key, value);
                     }
                     count++;
                 }

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueMap.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueMap.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interfaces.IJavetBiConsumer;
@@ -86,7 +87,7 @@ public class V8ValueMap extends V8ValueObject implements IV8ValueMap {
                     if (entry == null) {
                         break;
                     }
-                    try (Key key = entry.get(0); Value value = entry.get(1);) {
+                    try (Key key = entry.get(0); Value value = entry.get(1)) {
                         consumer.accept(key, value);
                     }
                     count++;
@@ -107,7 +108,7 @@ public class V8ValueMap extends V8ValueObject implements IV8ValueMap {
                     if (entry == null) {
                         break;
                     }
-                    try (Key key = entry.get(0); Value value = entry.get(1);) {
+                    try (Key key = entry.get(0); Value value = entry.get(1)) {
                         consumer.accept(count, key, value);
                     }
                     count++;
@@ -118,12 +119,14 @@ public class V8ValueMap extends V8ValueObject implements IV8ValueMap {
     }
 
     @Override
+    @CheckReturnValue
     public IV8ValueIterator<V8ValueArray> getEntries() throws JavetException {
         checkV8Runtime();
         return invoke(FUNCTION_ENTRIES);
     }
 
     @Override
+    @CheckReturnValue
     public IV8ValueIterator<? extends V8Value> getKeys() throws JavetException {
         checkV8Runtime();
         return invoke(FUNCTION_KEYS);
@@ -141,6 +144,7 @@ public class V8ValueMap extends V8ValueObject implements IV8ValueMap {
     }
 
     @Override
+    @CheckReturnValue
     public IV8ValueIterator<? extends V8Value> getValues() throws JavetException {
         checkV8Runtime();
         return invoke(FUNCTION_VALUES);

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueObject.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueObject.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.annotations.V8Function;
 import com.caoccao.javet.annotations.V8Property;
 import com.caoccao.javet.annotations.V8RuntimeSetter;
@@ -39,7 +40,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.*;
 
-@SuppressWarnings("unchecked")
 public class V8ValueObject extends V8ValueReference implements IV8ValueObject {
     protected static final String FUNCTION_ADD = "add";
     protected static final String FUNCTION_DELETE = "delete";
@@ -63,7 +63,7 @@ public class V8ValueObject extends V8ValueReference implements IV8ValueObject {
             if (method.isAnnotationPresent(V8Property.class)) {
                 V8Property v8Property = method.getAnnotation(V8Property.class);
                 String propertyName = v8Property.name();
-                if (propertyName == null || propertyName.length() == 0) {
+                if (propertyName.length() == 0) {
                     String methodName = method.getName();
                     if (methodName.startsWith(METHOD_PREFIX_IS)) {
                         propertyName = methodName.substring(METHOD_PREFIX_IS.length());
@@ -72,11 +72,11 @@ public class V8ValueObject extends V8ValueReference implements IV8ValueObject {
                     } else if (methodName.startsWith(METHOD_PREFIX_SET)) {
                         propertyName = methodName.substring(METHOD_PREFIX_SET.length());
                     }
-                    if (propertyName != null && propertyName.length() > 0) {
+                    if (propertyName.length() > 0) {
                         propertyName = propertyName.substring(0, 1).toLowerCase(Locale.ROOT) + propertyName.substring(1);
                     }
                 }
-                if (propertyName != null && propertyName.length() > 0) {
+                if (propertyName.length() > 0) {
                     if (method.getParameterCount() == 0) {
                         // Duplicated property name will be dropped.
                         if (!propertyGetterMap.containsKey(propertyName)) {
@@ -98,7 +98,7 @@ public class V8ValueObject extends V8ValueReference implements IV8ValueObject {
             } else if (method.isAnnotationPresent(V8Function.class)) {
                 V8Function v8Function = method.getAnnotation(V8Function.class);
                 String functionName = v8Function.name();
-                if (functionName == null || functionName.length() == 0) {
+                if (functionName.length() == 0) {
                     functionName = method.getName();
                 }
                 // Duplicated function will be dropped.
@@ -187,7 +187,7 @@ public class V8ValueObject extends V8ValueReference implements IV8ValueObject {
         return v8Runtime.setAccessor(this, propertyName, javetCallbackContextGetter, javetCallbackContextSetter);
     }
 
-    protected boolean bindV8Runtime(Object callbackReceiver, Method method) throws JavetException {
+    protected void bindV8Runtime(Object callbackReceiver, Method method) throws JavetException {
         if (method.isAnnotationPresent(V8RuntimeSetter.class)) {
             if (method.getParameterCount() != 1) {
                 throw new JavetException(JavetError.CallbackSignatureParameterSizeMismatch,
@@ -211,9 +211,7 @@ public class V8ValueObject extends V8ValueReference implements IV8ValueObject {
                         SimpleMap.of(JavetError.PARAMETER_MESSAGE, e.getMessage()),
                         e);
             }
-            return true;
         }
-        return false;
     }
 
     @Override
@@ -269,6 +267,7 @@ public class V8ValueObject extends V8ValueReference implements IV8ValueObject {
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T get(Object key) throws JavetException {
         checkV8Runtime();
         try (V8VirtualValue virtualKey = new V8VirtualValue(v8Runtime, key)) {
@@ -283,18 +282,21 @@ public class V8ValueObject extends V8ValueReference implements IV8ValueObject {
     }
 
     @Override
+    @CheckReturnValue
     public IV8ValueArray getOwnPropertyNames() throws JavetException {
         checkV8Runtime();
         return v8Runtime.getOwnPropertyNames(this);
     }
 
     @Override
+    @CheckReturnValue
     public IV8ValueArray getPropertyNames() throws JavetException {
         checkV8Runtime();
         return v8Runtime.getPropertyNames(this);
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T getProperty(Object key) throws JavetException {
         checkV8Runtime();
         try (V8VirtualValue virtualKey = new V8VirtualValue(v8Runtime, key)) {
@@ -324,6 +326,7 @@ public class V8ValueObject extends V8ValueReference implements IV8ValueObject {
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T invokeExtended(String functionName, boolean returnResult, Object... objects)
             throws JavetException {
         checkV8Runtime();
@@ -333,6 +336,7 @@ public class V8ValueObject extends V8ValueReference implements IV8ValueObject {
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T invokeExtended(String functionName, boolean returnResult, V8Value... v8Values)
             throws JavetException {
         checkV8Runtime();
@@ -342,7 +346,7 @@ public class V8ValueObject extends V8ValueReference implements IV8ValueObject {
 
     @Override
     public boolean sameValue(V8Value v8Value) throws JavetException {
-        if (v8Value == null || !(v8Value instanceof V8ValueObject)) {
+        if (!(v8Value instanceof V8ValueObject)) {
             return false;
         }
         if (v8Value.getClass() != this.getClass()) {

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueObject.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueObject.java
@@ -24,7 +24,9 @@ import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.exceptions.JavetError;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interfaces.IJavetBiConsumer;
-import com.caoccao.javet.interfaces.IJavetConsumer;
+import com.caoccao.javet.interfaces.IJavetBiIndexedConsumer;
+import com.caoccao.javet.interfaces.IJavetUniConsumer;
+import com.caoccao.javet.interfaces.IJavetUniIndexedConsumer;
 import com.caoccao.javet.interop.V8Runtime;
 import com.caoccao.javet.utils.JavetCallbackContext;
 import com.caoccao.javet.utils.SimpleMap;
@@ -224,7 +226,16 @@ public class V8ValueObject extends V8ValueReference implements IV8ValueObject {
 
     @Override
     public <Key extends V8Value, E extends Throwable> int forEach(
-            IJavetConsumer<Key, E> consumer) throws JavetException, E {
+            IJavetUniConsumer<Key, E> consumer) throws JavetException, E {
+        Objects.requireNonNull(consumer);
+        try (IV8ValueArray iV8ValueArray = getOwnPropertyNames()) {
+            return iV8ValueArray.forEach(consumer);
+        }
+    }
+
+    @Override
+    public <Key extends V8Value, E extends Throwable> int forEach(
+            IJavetUniIndexedConsumer<Key, E> consumer) throws JavetException, E {
         Objects.requireNonNull(consumer);
         try (IV8ValueArray iV8ValueArray = getOwnPropertyNames()) {
             return iV8ValueArray.forEach(consumer);
@@ -239,6 +250,19 @@ public class V8ValueObject extends V8ValueReference implements IV8ValueObject {
             return iV8ValueArray.forEach((Key key) -> {
                 try (Value value = get(key)) {
                     consumer.accept(key, value);
+                }
+            });
+        }
+    }
+
+    @Override
+    public <Key extends V8Value, Value extends V8Value, E extends Throwable> int forEach(
+            IJavetBiIndexedConsumer<Key, Value, E> consumer) throws JavetException, E {
+        Objects.requireNonNull(consumer);
+        try (IV8ValueArray iV8ValueArray = getOwnPropertyNames()) {
+            return iV8ValueArray.forEach((int index, Key key) -> {
+                try (Value value = get(key)) {
+                    consumer.accept(index, key, value);
                 }
             });
         }

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValuePromise.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValuePromise.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.V8Value;
 import com.caoccao.javet.enums.V8ValueReferenceType;
@@ -28,12 +29,14 @@ public class V8ValuePromise extends V8ValueObject implements IV8ValuePromise {
     }
 
     @Override
+    @CheckReturnValue
     public V8ValuePromise except(V8ValueFunction function) throws JavetException {
         checkV8Runtime();
         return v8Runtime.promiseCatch(this, function);
     }
 
     @Override
+    @CheckReturnValue
     public <Value extends V8Value> Value getResult() throws JavetException {
         checkV8Runtime();
         return v8Runtime.promiseGetResult(this);
@@ -63,6 +66,7 @@ public class V8ValuePromise extends V8ValueObject implements IV8ValuePromise {
     }
 
     @Override
+    @CheckReturnValue
     public V8ValuePromise then(IV8ValueFunction functionFulfilled, IV8ValueFunction functionRejected)
             throws JavetException{
         checkV8Runtime();

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueReference.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueReference.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.exceptions.JavetError;
 import com.caoccao.javet.exceptions.JavetException;
@@ -74,7 +75,7 @@ public abstract class V8ValueReference extends V8Value implements IV8ValueRefere
 
     @Override
     public boolean equals(V8Value v8Value) throws JavetException {
-        if (v8Value == null || !(v8Value instanceof V8ValueReference)) {
+        if (!(v8Value instanceof V8ValueReference)) {
             return false;
         }
         if (v8Value.getClass() != this.getClass()) {
@@ -96,7 +97,7 @@ public abstract class V8ValueReference extends V8Value implements IV8ValueRefere
     }
 
     @Override
-    public boolean isWeak() throws JavetException {
+    public boolean isWeak() {
         return weak;
     }
 
@@ -140,6 +141,7 @@ public abstract class V8ValueReference extends V8Value implements IV8ValueRefere
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T toClone() throws JavetException {
         checkV8Runtime();
         return v8Runtime.cloneV8Value(this);

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueSet.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueSet.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interfaces.IJavetUniConsumer;
@@ -82,6 +83,7 @@ public class V8ValueSet extends V8ValueObject implements IV8ValueSet {
     }
 
     @Override
+    @CheckReturnValue
     public IV8ValueIterator<V8ValueArray> getEntries() throws JavetException {
         checkV8Runtime();
         return invoke(FUNCTION_ENTRIES);
@@ -93,6 +95,7 @@ public class V8ValueSet extends V8ValueObject implements IV8ValueSet {
     }
 
     @Override
+    @CheckReturnValue
     public IV8ValueIterator<V8Value> getKeys() throws JavetException {
         checkV8Runtime();
         return invoke(FUNCTION_KEYS);

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueSet.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueSet.java
@@ -19,7 +19,8 @@ package com.caoccao.javet.values.reference;
 
 import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.exceptions.JavetException;
-import com.caoccao.javet.interfaces.IJavetConsumer;
+import com.caoccao.javet.interfaces.IJavetUniConsumer;
+import com.caoccao.javet.interfaces.IJavetUniIndexedConsumer;
 import com.caoccao.javet.values.V8Value;
 import com.caoccao.javet.values.virtual.V8VirtualValue;
 
@@ -44,7 +45,7 @@ public class V8ValueSet extends V8ValueObject implements IV8ValueSet {
 
     @Override
     public <Key extends V8Value, E extends Throwable> int forEach(
-            IJavetConsumer<Key, E> consumer) throws JavetException, E {
+            IJavetUniConsumer<Key, E> consumer) throws JavetException, E {
         Objects.requireNonNull(consumer);
         int count = 0;
         try (IV8ValueIterator<V8Value> iterator = getKeys()) {
@@ -54,6 +55,25 @@ public class V8ValueSet extends V8ValueObject implements IV8ValueSet {
                         break;
                     }
                     consumer.accept(key);
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    @Override
+    public <Key extends V8Value, E extends Throwable> int forEach(
+            IJavetUniIndexedConsumer<Key, E> consumer) throws JavetException, E {
+        Objects.requireNonNull(consumer);
+        int count = 0;
+        try (IV8ValueIterator<V8Value> iterator = getKeys()) {
+            while (true) {
+                try (Key key = (Key) iterator.getNext()) {
+                    if (key == null) {
+                        break;
+                    }
+                    consumer.accept(count, key);
                     count++;
                 }
             }

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueTypedArray.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueTypedArray.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.enums.V8ValueReferenceType;
 
@@ -110,6 +111,7 @@ public class V8ValueTypedArray extends V8ValueObject implements IV8ValueTypedArr
     }
 
     @Override
+    @CheckReturnValue
     public V8ValueArrayBuffer getBuffer() throws JavetException {
         return get(PROPERTY_BUFFER);
     }

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueWeakMap.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueWeakMap.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.exceptions.JavetError;
 import com.caoccao.javet.exceptions.JavetException;
@@ -41,12 +42,14 @@ public class V8ValueWeakMap extends V8ValueObject {
         return true;
     }
 
+    @CheckReturnValue
     public <T extends V8Value> T get(String key) throws JavetException {
         checkV8Runtime();
         return v8Runtime.get(this, v8Runtime.createV8ValueString(key));
     }
 
     @Override
+    @CheckReturnValue
     public <T extends V8Value> T get(Object key) throws JavetException {
         Objects.requireNonNull(key);
         if (!(key instanceof IV8ValueObject)) {
@@ -80,6 +83,7 @@ public class V8ValueWeakMap extends V8ValueObject {
     }
 
     @Override
+    @CheckReturnValue
     public V8ValueWeakMap toClone() throws JavetException {
         checkV8Runtime();
         return v8Runtime.cloneV8Value(this);

--- a/src/main/java/com/caoccao/javet/values/reference/V8ValueWeakSet.java
+++ b/src/main/java/com/caoccao/javet/values/reference/V8ValueWeakSet.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.enums.V8ValueReferenceType;
 import com.caoccao.javet.exceptions.JavetError;
 import com.caoccao.javet.exceptions.JavetException;
@@ -60,6 +61,7 @@ public class V8ValueWeakSet extends V8ValueObject {
     }
 
     @Override
+    @CheckReturnValue
     public V8ValueWeakSet toClone() throws JavetException {
         checkV8Runtime();
         return v8Runtime.cloneV8Value(this);

--- a/src/main/java/com/caoccao/javet/values/reference/builtin/V8ValueBuiltInPromise.java
+++ b/src/main/java/com/caoccao/javet/values/reference/builtin/V8ValueBuiltInPromise.java
@@ -17,6 +17,7 @@
 
 package com.caoccao.javet.values.reference.builtin;
 
+import com.caoccao.javet.annotations.CheckReturnValue;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.values.V8Value;
 import com.caoccao.javet.values.reference.V8ValueObject;
@@ -38,6 +39,7 @@ public class V8ValueBuiltInPromise extends V8ValueObject {
         super(handle);
     }
 
+    @CheckReturnValue
     public V8ValuePromise all(V8Value v8Value) throws JavetException {
         Objects.requireNonNull(v8Value);
         return invoke(FUNCTION_ALL, v8Value);
@@ -48,6 +50,7 @@ public class V8ValueBuiltInPromise extends V8ValueObject {
         invokeVoid(FUNCTION_ALL, v8Value);
     }
 
+    @CheckReturnValue
     public V8ValuePromise allSettled(V8Value v8Value) throws JavetException {
         Objects.requireNonNull(v8Value);
         return invoke(FUNCTION_ALL_SETTLED, v8Value);
@@ -58,6 +61,7 @@ public class V8ValueBuiltInPromise extends V8ValueObject {
         invokeVoid(FUNCTION_ALL_SETTLED, v8Value);
     }
 
+    @CheckReturnValue
     public V8ValuePromise any(V8Value v8Value) throws JavetException {
         Objects.requireNonNull(v8Value);
         return invoke(FUNCTION_ANY, v8Value);
@@ -68,6 +72,7 @@ public class V8ValueBuiltInPromise extends V8ValueObject {
         invokeVoid(FUNCTION_ANY, v8Value);
     }
 
+    @CheckReturnValue
     public V8ValuePromise race(V8Value v8Value) throws JavetException {
         Objects.requireNonNull(v8Value);
         return invoke(FUNCTION_RACE, v8Value);
@@ -83,6 +88,7 @@ public class V8ValueBuiltInPromise extends V8ValueObject {
         invokeVoid(FUNCTION_REJECT, v8Value);
     }
 
+    @CheckReturnValue
     public V8ValuePromise reject(V8Value v8Value) throws JavetException {
         Objects.requireNonNull(v8Value);
         return invoke(FUNCTION_REJECT, v8Value);
@@ -93,6 +99,7 @@ public class V8ValueBuiltInPromise extends V8ValueObject {
         invokeVoid(FUNCTION_RESOLVE, v8Value);
     }
 
+    @CheckReturnValue
     public V8ValuePromise resolve(V8Value v8Value) throws JavetException {
         Objects.requireNonNull(v8Value);
         return invoke(FUNCTION_RESOLVE, v8Value);

--- a/src/test/java/com/caoccao/javet/interop/engine/TestJavetEnginePool.java
+++ b/src/test/java/com/caoccao/javet/interop/engine/TestJavetEnginePool.java
@@ -31,6 +31,7 @@ import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@SuppressWarnings("unchecked")
 public class TestJavetEnginePool extends BaseTestJavet {
     public static final int TEST_POOL_DAEMON_CHECK_INTERVAL_MILLIS = 1;
     public static final int TEST_MAX_TIMEOUT = 1000;

--- a/src/test/java/com/caoccao/javet/tutorial/HelloJavet.java
+++ b/src/test/java/com/caoccao/javet/tutorial/HelloJavet.java
@@ -55,7 +55,7 @@ public class HelloJavet {
 
     public void playWithPoolAndConsole() throws JavetException {
         // Create a Javet engine pool.
-        try (IJavetEnginePool<V8Runtime> javetEnginePool = new JavetEnginePool<V8Runtime>()) {
+        try (IJavetEnginePool<V8Runtime> javetEnginePool = new JavetEnginePool<>()) {
             // Get a Javet engine from the pool.
             try (IJavetEngine<V8Runtime> javetEngine = javetEnginePool.getEngine()) {
                 // Get a V8 runtime from the engine.

--- a/src/test/java/com/caoccao/javet/tutorial/TestInterception.java
+++ b/src/test/java/com/caoccao/javet/tutorial/TestInterception.java
@@ -1,0 +1,107 @@
+/*
+ *   Copyright (c) 2021. caoccao.com Sam Cao
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+package com.caoccao.javet.tutorial;
+
+import com.caoccao.javet.annotations.V8Function;
+import com.caoccao.javet.annotations.V8Property;
+import com.caoccao.javet.exceptions.JavetException;
+import com.caoccao.javet.interception.logging.JavetStandardConsoleInterceptor;
+import com.caoccao.javet.interop.V8Host;
+import com.caoccao.javet.interop.V8Runtime;
+import com.caoccao.javet.values.reference.V8ValueObject;
+
+public class TestInterception {
+    private String name;
+    private int value;
+
+    public static void main(String[] args) throws JavetException {
+        // Step 1: Create a V8 runtime from V8 host in try-with-resource.
+        try (V8Runtime v8Runtime = V8Host.getV8Instance().createV8Runtime()) {
+            // Step 2: Register console.
+            JavetStandardConsoleInterceptor javetStandardConsoleInterceptor = new JavetStandardConsoleInterceptor(v8Runtime);
+            javetStandardConsoleInterceptor.register(v8Runtime.getGlobalObject());
+            // Step 3: Create an interceptor.
+            TestInterception testInterceptor = new TestInterception();
+            // Step 4: Bind the interceptor to a variable.
+            try (V8ValueObject v8ValueObject = v8Runtime.createV8ValueObject()) {
+                v8Runtime.getGlobalObject().set("a", v8ValueObject);
+                v8ValueObject.bind(testInterceptor);
+            }
+
+            // Test property name
+            v8Runtime.getExecutor("console.log(`a.name is initially ${a.name}.`);").executeVoid(); // null
+            // a.name setter => setName(String name)
+            v8Runtime.getExecutor("a.name = 'Javet';").executeVoid();
+            // name is changed
+            System.out.println("Interceptor name is " + testInterceptor.getName() + "."); // Javet
+            // a.name getter => getName()
+            v8Runtime.getExecutor("console.log(`a.name is now ${a.name}.`);").executeVoid(); // Javet
+
+            // Test property value
+            v8Runtime.getExecutor("console.log(`a.value is initially ${a.value}.`);").executeVoid(); // 0
+            // a.value setter => setValue(String value)
+            v8Runtime.getExecutor("a.value = 123;").executeVoid();
+            // value is changed
+            System.out.println("Interceptor value is " + testInterceptor.getValue() + "."); // 123
+            // a.value getter => getValue()
+            v8Runtime.getExecutor("console.log(`a.value is now ${a.value}.`);").executeVoid(); // 123
+
+            // Test functions
+            v8Runtime.getExecutor("console.log(`a.increaseAndGet() is ${a.increaseAndGet()}.`);").executeVoid(); // 124
+            v8Runtime.getExecutor("console.log(`a.add(76) is ${a.add(76)}.`);").executeVoid(); // 200
+
+            // Step 5: Delete the interceptor.
+            v8Runtime.getGlobalObject().delete("a");
+            // Step 6: Unregister console.
+            javetStandardConsoleInterceptor.unregister(v8Runtime.getGlobalObject());
+            // Step 7: Notify V8 to perform GC. (Optional)
+            v8Runtime.lowMemoryNotification();
+        }
+    }
+
+    @V8Property
+    public String getName() {
+        return name;
+    }
+
+    @V8Property
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @V8Property
+    public int getValue() {
+        return value;
+    }
+
+    @V8Property
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+    @V8Function
+    public int increaseAndGet() {
+        return ++value;
+    }
+
+    @V8Function
+    public int add(int delta) {
+        value += delta;
+        return value;
+    }
+}

--- a/src/test/java/com/caoccao/javet/values/reference/TestV8ValueArray.java
+++ b/src/test/java/com/caoccao/javet/values/reference/TestV8ValueArray.java
@@ -36,6 +36,9 @@ public class TestV8ValueArray extends BaseTestJavetRuntime {
             v8ValueArray.forEach((V8ValueInteger value) -> {
                 assertEquals(count.getAndIncrement(), value.getValue());
             });
+            v8ValueArray.forEach((int index, V8ValueInteger value) -> {
+                assertEquals(index, value.getValue());
+            });
         }
     }
 

--- a/src/test/java/com/caoccao/javet/values/reference/TestV8ValueFunction.java
+++ b/src/test/java/com/caoccao/javet/values/reference/TestV8ValueFunction.java
@@ -592,11 +592,14 @@ public class TestV8ValueFunction extends BaseTestJavetRuntime {
             assertEquals(1, v8Runtime.getReferenceCount());
             assertEquals(1, v8Runtime.getCallbackContextCount());
             mockCallbackReceiver.setCalled(false);
-            assertFalse(mockCallbackReceiver.isCalled());
-            String resultString = v8Runtime.getExecutor("a.test").executeString();
+            assertEquals("abc", v8Runtime.getExecutor("a.test").executeString());
             assertTrue(mockCallbackReceiver.isCalled());
-            assertEquals("abc", resultString);
+            mockCallbackReceiver.setCalled(false);
+            assertEquals("abc", v8Runtime.getExecutor("a['test']").executeString());
+            assertTrue(mockCallbackReceiver.isCalled());
+            mockCallbackReceiver.setCalled(false);
             assertEquals("{\"test\":\"abc\"}", v8ValueObject.toJsonString());
+            assertTrue(mockCallbackReceiver.isCalled());
             globalObject.delete("a");
         }
         v8Runtime.requestGarbageCollectionForTesting(true);
@@ -624,10 +627,14 @@ public class TestV8ValueFunction extends BaseTestJavetRuntime {
             assertEquals("abc", mockCallbackReceiver.getValue());
             assertEquals("{\"test\":\"abc\"}", v8ValueObject.toJsonString());
             mockCallbackReceiver.setCalled(false);
-            String resultString = v8Runtime.getExecutor("a.test").executeString();
+            assertEquals("abc", v8Runtime.getExecutor("a.test").executeString());
             assertTrue(mockCallbackReceiver.isCalled());
-            assertEquals("abc", resultString);
+            mockCallbackReceiver.setCalled(false);
+            assertEquals("abc", v8Runtime.getExecutor("a['test']").executeString());
+            assertTrue(mockCallbackReceiver.isCalled());
+            mockCallbackReceiver.setCalled(false);
             assertEquals("{\"test\":\"abc\"}", v8ValueObject.toJsonString());
+            assertTrue(mockCallbackReceiver.isCalled());
             globalObject.delete("a");
         }
         v8Runtime.requestGarbageCollectionForTesting(true);

--- a/src/test/java/com/caoccao/javet/values/reference/TestV8ValueFunction.java
+++ b/src/test/java/com/caoccao/javet/values/reference/TestV8ValueFunction.java
@@ -47,8 +47,8 @@ public class TestV8ValueFunction extends BaseTestJavetRuntime {
             MockAnnotationBasedCallbackReceiver mockAnnotationBasedCallbackReceiver =
                     new MockAnnotationBasedCallbackReceiver();
             List<JavetCallbackContext> javetCallbackContexts =
-                    v8ValueObject.bindFunctions(mockAnnotationBasedCallbackReceiver);
-            assertEquals(14, javetCallbackContexts.size());
+                    v8ValueObject.bind(mockAnnotationBasedCallbackReceiver);
+            assertEquals(17, javetCallbackContexts.size());
             assertEquals(0, mockAnnotationBasedCallbackReceiver.getCount());
             assertEquals("test", v8Runtime.getExecutor("a.echo('test')").executeString());
             assertEquals(1, mockAnnotationBasedCallbackReceiver.getCount());
@@ -520,7 +520,7 @@ public class TestV8ValueFunction extends BaseTestJavetRuntime {
         try (V8ValueObject v8ValueObject = v8Runtime.getGlobalObject().get("x")) {
             MockAnnotationBasedCallbackReceiver mockAnnotationBasedCallbackReceiver =
                     new MockAnnotationBasedCallbackReceiver();
-            v8ValueObject.bindFunctions(mockAnnotationBasedCallbackReceiver);
+            v8ValueObject.bind(mockAnnotationBasedCallbackReceiver);
             assertEquals(3, iV8Executor.executeInteger());
             v8ValueObject.forEach((key) -> v8ValueObject.delete(key));
         } catch (JavetExecutionException e) {

--- a/src/test/java/com/caoccao/javet/values/reference/TestV8ValueFunction.java
+++ b/src/test/java/com/caoccao/javet/values/reference/TestV8ValueFunction.java
@@ -293,11 +293,18 @@ public class TestV8ValueFunction extends BaseTestJavetRuntime {
         try (V8ValueFunction v8ValueFunction = v8Runtime.createV8ValueFunction(javetCallbackContext)) {
             assertEquals(1, v8Runtime.getReferenceCount());
             globalObject.set("echoString", v8ValueFunction);
-            assertFalse(mockCallbackReceiver.isCalled());
-            assertEquals("abc", v8Runtime.getExecutor("const a = echoString('abc'); a;").executeString());
         }
-        globalObject.delete("echoString");
+        assertFalse(mockCallbackReceiver.isCalled());
+        assertEquals("abc", v8Runtime.getExecutor("echoString('abc')").executeString());
         assertTrue(mockCallbackReceiver.isCalled());
+        globalObject.delete("echoString");
+        javetCallbackContext = new JavetCallbackContext(
+                mockCallbackReceiver, mockCallbackReceiver.getMethod("echoString", V8Value[].class));
+        globalObject.bindFunction("echoString", javetCallbackContext);
+        assertEquals("abc", v8Runtime.getExecutor("echoString('abc')").executeString());
+        assertEquals("abc,def", v8Runtime.getExecutor("echoString('abc', 'def')").executeString());
+        assertEquals("", v8Runtime.getExecutor("echoString()").executeString());
+        globalObject.delete("echoString");
         v8Runtime.requestGarbageCollectionForTesting(true);
     }
 

--- a/src/test/java/com/caoccao/javet/values/reference/TestV8ValueMap.java
+++ b/src/test/java/com/caoccao/javet/values/reference/TestV8ValueMap.java
@@ -46,6 +46,16 @@ public class TestV8ValueMap extends BaseTestJavetRuntime {
                 assertEquals(Integer.toString(count.get()), key.getValue());
                 assertEquals(count.getAndIncrement(), value.getValue());
             }));
+            assertEquals(3, v8ValueMap.forEach((int index, V8ValueString key) -> {
+                assertNotNull(key);
+                assertEquals(Integer.toString(index), key.getValue());
+            }));
+            assertEquals(3, v8ValueMap.forEach((int index, V8ValueString key, V8ValueInteger value) -> {
+                assertNotNull(key);
+                assertNotNull(value);
+                assertEquals(Integer.toString(index), key.getValue());
+                assertEquals(index, value.getValue());
+            }));
         }
     }
 

--- a/src/test/java/com/caoccao/javet/values/reference/TestV8ValueObject.java
+++ b/src/test/java/com/caoccao/javet/values/reference/TestV8ValueObject.java
@@ -44,8 +44,8 @@ public class TestV8ValueObject extends BaseTestJavetRuntime {
             MockAnnotationBasedCallbackReceiver mockAnnotationBasedCallbackReceiver =
                     new MockAnnotationBasedCallbackReceiver();
             List<JavetCallbackContext> javetCallbackContexts =
-                    v8ValueObject.bindProperties(mockAnnotationBasedCallbackReceiver);
-            assertEquals(3, javetCallbackContexts.size());
+                    v8ValueObject.bind(mockAnnotationBasedCallbackReceiver);
+            assertEquals(17, javetCallbackContexts.size());
             assertEquals(0, mockAnnotationBasedCallbackReceiver.getCount());
             assertEquals(123, v8Runtime.getExecutor("a.integerValue").executeInteger());
             assertEquals(1, mockAnnotationBasedCallbackReceiver.getCount());

--- a/src/test/java/com/caoccao/javet/values/reference/TestV8ValueObject.java
+++ b/src/test/java/com/caoccao/javet/values/reference/TestV8ValueObject.java
@@ -97,6 +97,13 @@ public class TestV8ValueObject extends BaseTestJavetRuntime {
                 assertEquals("A" + Integer.toString(count.get()), key.getValue());
                 assertEquals(count.getAndIncrement(), value.getValue());
             }));
+            assertEquals(3, v8ValueObject.forEach((int index, V8ValueString key) -> {
+                assertEquals("A" + Integer.toString(index), key.getValue());
+            }));
+            assertEquals(3, v8ValueObject.forEach((int index, V8ValueString key, V8ValueInteger value) -> {
+                assertEquals("A" + Integer.toString(index), key.getValue());
+                assertEquals(index, value.getValue());
+            }));
         }
     }
 

--- a/src/test/java/com/caoccao/javet/values/reference/TestV8ValueObject.java
+++ b/src/test/java/com/caoccao/javet/values/reference/TestV8ValueObject.java
@@ -49,10 +49,14 @@ public class TestV8ValueObject extends BaseTestJavetRuntime {
             assertEquals(0, mockAnnotationBasedCallbackReceiver.getCount());
             assertEquals(123, v8Runtime.getExecutor("a.integerValue").executeInteger());
             assertEquals(1, mockAnnotationBasedCallbackReceiver.getCount());
-            v8Runtime.getExecutor("a.stringValue = 'abc';").executeVoid();
+            assertEquals(123, v8Runtime.getExecutor("a['integerValue']").executeInteger());
             assertEquals(2, mockAnnotationBasedCallbackReceiver.getCount());
-            assertEquals("abc", v8Runtime.getExecutor("a.stringValue").executeString());
+            v8Runtime.getExecutor("a.stringValue = 'abc';").executeVoid();
             assertEquals(3, mockAnnotationBasedCallbackReceiver.getCount());
+            assertEquals("abc", v8Runtime.getExecutor("a.stringValue").executeString());
+            assertEquals(4, mockAnnotationBasedCallbackReceiver.getCount());
+            assertEquals("abc", v8Runtime.getExecutor("a['stringValue']").executeString());
+            assertEquals(5, mockAnnotationBasedCallbackReceiver.getCount());
             v8Runtime.getGlobalObject().delete("a");
         }
         v8Runtime.requestGarbageCollectionForTesting(true);

--- a/src/test/java/com/caoccao/javet/values/reference/TestV8ValueSet.java
+++ b/src/test/java/com/caoccao/javet/values/reference/TestV8ValueSet.java
@@ -68,6 +68,9 @@ public class TestV8ValueSet extends BaseTestJavetRuntime {
             assertEquals(3, v8ValueSet.forEach((V8ValueString key) -> {
                 assertEquals(Integer.toString(count.getAndIncrement()), key.getValue());
             }));
+            assertEquals(3, v8ValueSet.forEach((int index, V8ValueString key) -> {
+                assertEquals(Integer.toString(index), key.getValue());
+            }));
         }
     }
 


### PR DESCRIPTION
* Renamed ``IJavetConsumer`` to ``IJavetUniConsumer``
* Added ``IJavetUniIndexedConsumer`` and ``IJavetBiIndexedConsumer``
* Fixed a bug in ``V8FunctionCallback`` on varargs
* Deprecated ``bindFunctions()`` and ``bindProperties()``
* Added ``@CheckReturnValue`` to warn ignored return value