### PR TITLE
Add Javadocs to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,5 +102,5 @@ Documents
 =========
 
 * `Javet Intro <https://docs.google.com/presentation/d/1lQ8xIHuywuE0ydqm2w6xq8OeQZO_WeTLYXW9bNflQb8/>`_
+* `Javet Javadoc <https://www.caoccao.com/Javet/reference/javadoc/index.html>`_
 * `Javet Document Portal <https://www.caoccao.com/Javet/>`_
-* `Javet Javadocs <https://www.caoccao.com/Javet/reference/javadoc/index.html>`_


### PR DESCRIPTION
This is a very minor thing, but it'll make it a little bit easier for anyone to find Javet's Javadocs.