### PR TITLE
Infra/redesign docker build

### DIFF
--- a/.github/workflows/linux_build_artifact.yml
+++ b/.github/workflows/linux_build_artifact.yml
@@ -16,7 +16,7 @@ on:
       - "docs/**"
 
 env:
-  JAVET_VERSION: 2.0.1
+  JAVET_VERSION: x86_64-2.0.1
 
 jobs:
   javet_linux_x86_64:

--- a/.github/workflows/linux_build_artifact.yml
+++ b/.github/workflows/linux_build_artifact.yml
@@ -16,6 +16,8 @@ on:
       - "docs/**"
 
 env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_REPO_JAVET: ${{ secrets.DOCKERHUB_REPO_JAVET }}
   JAVET_VERSION: x86_64-2.0.1
 
 jobs:
@@ -28,7 +30,7 @@ jobs:
 
       - name: Set the JAVET_GRADLE_IMAGE_TAG environment variable
         run: |
-          echo 'JAVET_GRADLE_IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:${{ env.JAVET_VERSION}}' >> $GITHUB_ENV
+          echo 'JAVET_GRADLE_IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPO_JAVET }}:${{ env.JAVET_VERSION}}' >> $GITHUB_ENV
 
       - name: Build the artifact
         run: |

--- a/.github/workflows/linux_build_artifact.yml
+++ b/.github/workflows/linux_build_artifact.yml
@@ -14,8 +14,6 @@ on:
     paths-ignore:
       - "**.rst"
       - "docs/**"
-    branches:
-      - infra/redesign_docker_build
 
 env:
   JAVET_GRADLE_IMAGE_TAG: amithgeorge/javet-linux-dev:2.0.1

--- a/.github/workflows/linux_build_artifact.yml
+++ b/.github/workflows/linux_build_artifact.yml
@@ -16,7 +16,7 @@ on:
       - "docs/**"
 
 env:
-  JAVET_GRADLE_IMAGE_TAG: amithgeorge/javet-linux-dev:2.0.1
+  JAVET_VERSION: 2.0.1
 
 jobs:
   javet_linux_x86_64:
@@ -25,6 +25,10 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v3
+
+      - name: Set the JAVET_GRADLE_IMAGE_TAG environment variable
+        run: |
+          echo 'JAVET_GRADLE_IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:${{ env.JAVET_VERSION}}' >> $GITHUB_ENV
 
       - name: Build the artifact
         run: |

--- a/.github/workflows/linux_build_artifact.yml
+++ b/.github/workflows/linux_build_artifact.yml
@@ -14,6 +14,8 @@ on:
     paths-ignore:
       - "**.rst"
       - "docs/**"
+    branches:
+      - infra/redesign_docker_build
 
 env:
   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/linux_build_artifact.yml
+++ b/.github/workflows/linux_build_artifact.yml
@@ -1,0 +1,44 @@
+name: Linux build artifact
+concurrency:
+  group: linux_build_artifact_${{ github.ref }}
+  cancel-in-progress: true
+on:
+  # trigger manually
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "**.rst"
+      - "docs/**"
+  push:
+    paths-ignore:
+      - "**.rst"
+      - "docs/**"
+    branches:
+      - infra/redesign_docker_build
+
+env:
+  JAVET_GRADLE_IMAGE_TAG: amithgeorge/javet-linux-dev:2.0.1
+
+jobs:
+  javet_linux_x86_64:
+    name: Javet Linux x86_64
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Build the artifact
+        run: |
+          docker build -t javet:local \
+            --build-arg JAVET_GRADLE_IMAGE_TAG=${{ env.JAVET_GRADLE_IMAGE_TAG }} \
+            -f docker/linux-x86_64/artifact.Dockerfile .
+
+      - name: Copy the artifact
+        run: mkdir $PWD/build && docker run --rm -i -v $PWD/build:/output javet:local cp -rf /Javet/build/libs /output
+
+      - name: Upload the artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: javet-linux-x86_64
+          path: build/libs/javet*.jar

--- a/.github/workflows/linux_build_dev_image.yml
+++ b/.github/workflows/linux_build_dev_image.yml
@@ -12,8 +12,8 @@ on:
       - "*"
 
 env:
-  JAVET_V8_NODE_IMAGE_VERSION: v8-10.7.193.16_node-18.12.0
-  JAVET_VERSION: 2.0.1
+  JAVET_V8_NODE_IMAGE_VERSION: x86_64-v8-10.7.193.16_node-18.12.0
+  JAVET_VERSION: x86_64-2.0.1
 
 jobs:
   publish_v8_node:

--- a/.github/workflows/linux_build_dev_image.yml
+++ b/.github/workflows/linux_build_dev_image.yml
@@ -10,8 +10,6 @@ on:
   push:
     tags:
       - "*"
-    branches:
-      - infra/redesign_docker_build
 
 env:
   DOCKERHUB_USERNAME: amithgeorge

--- a/.github/workflows/linux_build_dev_image.yml
+++ b/.github/workflows/linux_build_dev_image.yml
@@ -12,6 +12,8 @@ on:
       - "*"
 
 env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_REPO_JAVET: ${{ secrets.DOCKERHUB_REPO_JAVET }}
   JAVET_V8_NODE_IMAGE_VERSION: x86_64-v8-10.7.193.16_node-18.12.0
   JAVET_VERSION: x86_64-2.0.1
 
@@ -22,8 +24,8 @@ jobs:
     steps:
       - name: Set the IMAGE_TAG, JAVET_V8_NODE_IMAGE_TAG environment variable
         run: |
-          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:${{ env.JAVET_VERSION }}' >> $GITHUB_ENV
-          echo 'JAVET_V8_NODE_IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:${{ env.JAVET_V8_NODE_IMAGE_VERSION }}' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPO_JAVET }}:${{ env.JAVET_VERSION }}' >> $GITHUB_ENV
+          echo 'JAVET_V8_NODE_IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPO_JAVET }}:${{ env.JAVET_V8_NODE_IMAGE_VERSION }}' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a

--- a/.github/workflows/linux_build_dev_image.yml
+++ b/.github/workflows/linux_build_dev_image.yml
@@ -12,8 +12,7 @@ on:
       - "*"
 
 env:
-  DOCKERHUB_USERNAME: amithgeorge
-  JAVET_V8_NODE_IMAGE_TAG: amithgeorge/javet-linux-dev:v8-10.7.193.16_node-18.12.0
+  JAVET_V8_NODE_IMAGE_VERSION: v8-10.7.193.16_node-18.12.0
   JAVET_VERSION: 2.0.1
 
 jobs:
@@ -21,14 +20,15 @@ jobs:
     name: Dev image with Gradle deps - Publish container image with V8, Node.js and Gradle dependencies
     runs-on: ubuntu-latest
     steps:
-      - name: Set the IMAGE_TAG environment variable
+      - name: Set the IMAGE_TAG, JAVET_V8_NODE_IMAGE_TAG environment variable
         run: |
-          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/javet-linux-dev:${{ env.JAVET_VERSION }}' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:${{ env.JAVET_VERSION }}' >> $GITHUB_ENV
+          echo 'JAVET_V8_NODE_IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:${{ env.JAVET_V8_NODE_IMAGE_VERSION }}' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Checkout the code

--- a/.github/workflows/linux_build_dev_image.yml
+++ b/.github/workflows/linux_build_dev_image.yml
@@ -1,0 +1,49 @@
+name: Linux build dev image - Gradle deps, V8, Node
+
+concurrency:
+  group: linux_build_dev
+  cancel-in-progress: true
+
+# we need to provide some value for tags, else GH runs the workflow on every push to any branch, even if not tagged
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "*"
+    branches:
+      - infra/redesign_docker_build
+
+env:
+  DOCKERHUB_USERNAME: amithgeorge
+  JAVET_V8_NODE_IMAGE_TAG: amithgeorge/javet-linux-dev:v8-10.7.193.16_node-18.12.0
+  JAVET_VERSION: 2.0.1
+
+jobs:
+  publish_v8_node:
+    name: Dev image with Gradle deps - Publish container image with V8, Node.js and Gradle dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set the IMAGE_TAG environment variable
+        run: |
+          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/javet-linux-dev:${{ env.JAVET_VERSION }}' >> $GITHUB_ENV
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Build docker image
+        run: |
+          echo 'IMAGE_TAG is ${{ env.IMAGE_TAG }}'
+          docker build \
+            -t ${{ env.IMAGE_TAG }} \
+            --build-arg JAVET_V8_NODE_IMAGE_TAG=${{ env.JAVET_V8_NODE_IMAGE_TAG }} \
+            -f docker/linux-x86_64/gradle.Dockerfile .
+
+      - name: Publish the docker image
+        run: |
+          docker push ${{ env.IMAGE_TAG }}

--- a/.github/workflows/linux_build_dev_image.yml
+++ b/.github/workflows/linux_build_dev_image.yml
@@ -10,6 +10,8 @@ on:
   push:
     tags:
       - "*"
+    branches:
+      - infra/redesign_docker_build
 
 env:
   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/linux_build_node_v8_image.yml
+++ b/.github/workflows/linux_build_node_v8_image.yml
@@ -13,7 +13,6 @@ on:
         type: boolean
 
 env:
-  DOCKERHUB_USERNAME: amithgeorge
   JAVET_V8_VERSION: 10.7.193.16
   JAVET_NODE_VERSION: 18.12.0
 
@@ -30,13 +29,13 @@ jobs:
       - name: Set the IMAGE_TAG environment variable
         if: inputs.skip_base_jvm == false
         run: |
-          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/javet-linux-dev:base-jvm-latest' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:base-jvm-latest' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         if: inputs.skip_base_jvm == false
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Checkout the code
@@ -64,13 +63,13 @@ jobs:
       - name: Set the IMAGE_TAG environment variable
         if: inputs.skip_base_v8 == false
         run: |
-          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/javet-linux-dev:base-v8-${{ env.JAVET_V8_VERSION }}' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:base-v8-${{ env.JAVET_V8_VERSION }}' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         if: inputs.skip_base_v8 == false
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Checkout the code
@@ -99,13 +98,13 @@ jobs:
       - name: Set the IMAGE_TAG environment variable
         if: inputs.skip_base_node == false
         run: |
-          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/javet-linux-dev:base-node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:base-node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         if: inputs.skip_base_node == false
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Checkout the code
@@ -133,12 +132,12 @@ jobs:
     steps:
       - name: Set the IMAGE_TAG environment variable
         run: |
-          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/javet-linux-dev:v8-${{ env.JAVET_V8_VERSION }}_node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:v8-${{ env.JAVET_V8_VERSION }}_node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
         with:
-          username: ${{ env.DOCKERHUB_USERNAME }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Checkout the code

--- a/.github/workflows/linux_build_node_v8_image.yml
+++ b/.github/workflows/linux_build_node_v8_image.yml
@@ -11,6 +11,9 @@ on:
       skip_base_node:
         default: false
         type: boolean
+  push:
+    branches:
+      - infra/redesign_docker_build
 
 env:
   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/.github/workflows/linux_build_node_v8_image.yml
+++ b/.github/workflows/linux_build_node_v8_image.yml
@@ -13,6 +13,8 @@ on:
         type: boolean
 
 env:
+  DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_REPO_JAVET: ${{ secrets.DOCKERHUB_REPO_JAVET }}
   JAVET_V8_VERSION: 10.7.193.16
   JAVET_NODE_VERSION: 18.12.0
 
@@ -29,7 +31,7 @@ jobs:
       - name: Set the IMAGE_TAG environment variable
         if: inputs.skip_base_jvm == false
         run: |
-          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:x86_64-base-jvm-latest' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPO_JAVET }}:x86_64-base-jvm-latest' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         if: inputs.skip_base_jvm == false
@@ -63,7 +65,7 @@ jobs:
       - name: Set the IMAGE_TAG environment variable
         if: inputs.skip_base_v8 == false
         run: |
-          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:x86_64-base-v8-${{ env.JAVET_V8_VERSION }}' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPO_JAVET }}:x86_64-base-v8-${{ env.JAVET_V8_VERSION }}' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         if: inputs.skip_base_v8 == false
@@ -98,7 +100,7 @@ jobs:
       - name: Set the IMAGE_TAG environment variable
         if: inputs.skip_base_node == false
         run: |
-          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:x86_64-base-node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPO_JAVET }}:x86_64-base-node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         if: inputs.skip_base_node == false
@@ -132,7 +134,7 @@ jobs:
     steps:
       - name: Set the IMAGE_TAG environment variable
         run: |
-          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:x86_64-v8-${{ env.JAVET_V8_VERSION }}_node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPO_JAVET }}:x86_64-v8-${{ env.JAVET_V8_VERSION }}_node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a

--- a/.github/workflows/linux_build_node_v8_image.yml
+++ b/.github/workflows/linux_build_node_v8_image.yml
@@ -11,9 +11,6 @@ on:
       skip_base_node:
         default: false
         type: boolean
-  push:
-    branches:
-      - infra/redesign_docker_build
 
 env:
   DOCKERHUB_USERNAME: amithgeorge

--- a/.github/workflows/linux_build_node_v8_image.yml
+++ b/.github/workflows/linux_build_node_v8_image.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set the IMAGE_TAG environment variable
         if: inputs.skip_base_jvm == false
         run: |
-          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:base-jvm-latest' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:x86_64-base-jvm-latest' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         if: inputs.skip_base_jvm == false
@@ -63,7 +63,7 @@ jobs:
       - name: Set the IMAGE_TAG environment variable
         if: inputs.skip_base_v8 == false
         run: |
-          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:base-v8-${{ env.JAVET_V8_VERSION }}' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:x86_64-base-v8-${{ env.JAVET_V8_VERSION }}' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         if: inputs.skip_base_v8 == false
@@ -98,7 +98,7 @@ jobs:
       - name: Set the IMAGE_TAG environment variable
         if: inputs.skip_base_node == false
         run: |
-          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:base-node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:x86_64-base-node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         if: inputs.skip_base_node == false
@@ -132,7 +132,7 @@ jobs:
     steps:
       - name: Set the IMAGE_TAG environment variable
         run: |
-          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:v8-${{ env.JAVET_V8_VERSION }}_node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
+          echo 'IMAGE_TAG=${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_REPO_JAVET }}:x86_64-v8-${{ env.JAVET_V8_VERSION }}_node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a

--- a/.github/workflows/linux_build_node_v8_image.yml
+++ b/.github/workflows/linux_build_node_v8_image.yml
@@ -87,6 +87,7 @@ jobs:
           echo 'IMAGE_TAG is ${{ env.IMAGE_TAG }}'
           docker build \
             -t ${{ env.IMAGE_TAG }} \
+            --build-arg JAVET_REPO=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPO_JAVET }} \
             --build-arg JAVET_V8_VERSION=${{ env.JAVET_V8_VERSION }} \
             -f docker/linux-x86_64/base-v8.Dockerfile .
 
@@ -122,6 +123,7 @@ jobs:
           echo 'IMAGE_TAG is ${{ env.IMAGE_TAG }}'
           docker build \
             -t ${{ env.IMAGE_TAG }} \
+            --build-arg JAVET_REPO=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPO_JAVET }} \
             --build-arg JAVET_NODE_VERSION=${{ env.JAVET_NODE_VERSION }} \
             -f docker/linux-x86_64/base-node.Dockerfile .
 
@@ -153,6 +155,7 @@ jobs:
           echo 'IMAGE_TAG is ${{ env.IMAGE_TAG }}'
           docker build \
             -t ${{ env.IMAGE_TAG }} \
+            --build-arg JAVET_REPO=${{ env.DOCKERHUB_USERNAME }}/${{ env.DOCKERHUB_REPO_JAVET }} \
             --build-arg JAVET_V8_VERSION=${{ env.JAVET_V8_VERSION }} \
             --build-arg JAVET_NODE_VERSION=${{ env.JAVET_NODE_VERSION }} \
             -f docker/linux-x86_64/v8_node.Dockerfile .

--- a/.github/workflows/linux_build_node_v8_image.yml
+++ b/.github/workflows/linux_build_node_v8_image.yml
@@ -1,0 +1,161 @@
+name: Linux build V8 and Node image
+on:
+  workflow_dispatch:
+    inputs:
+      skip_base_jvm:
+        default: false
+        type: boolean
+      skip_base_v8:
+        default: false
+        type: boolean
+      skip_base_node:
+        default: false
+        type: boolean
+  push:
+    branches:
+      - infra/redesign_docker_build
+
+env:
+  DOCKERHUB_USERNAME: amithgeorge
+  JAVET_V8_VERSION: 10.7.193.16
+  JAVET_NODE_VERSION: 18.12.0
+
+# if we skip a job using a job level `if` condition, then any dependent jobs also don't run.
+# we can skip a step of the job, using a step level `if` condition.
+# however GitHub doesn't support skipping all subsequent steps of a job.
+# we need to add the condition to every step.
+
+jobs:
+  publish_base_jvm:
+    name: Ubuntu, build tools and JDK 8 - Publish container image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set the IMAGE_TAG environment variable
+        if: inputs.skip_base_jvm == false
+        run: |
+          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/javet-linux-dev:base-jvm-latest' >> $GITHUB_ENV
+
+      - name: Login to Docker Hub
+        if: inputs.skip_base_jvm == false
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Checkout the code
+        if: inputs.skip_base_jvm == false
+        uses: actions/checkout@v3
+
+      - name: Build docker image
+        if: inputs.skip_base_jvm == false
+        run: |
+          echo 'IMAGE_TAG is ${{ env.IMAGE_TAG }}'
+          docker build \
+            -t ${{ env.IMAGE_TAG }} \
+            -f docker/linux-x86_64/base-jvm.Dockerfile .
+
+      - name: Publish the docker image
+        if: inputs.skip_base_jvm == false
+        run: |
+          docker push ${{ env.IMAGE_TAG }}
+
+  publish_base_v8:
+    needs: [publish_base_jvm]
+    name: V8 - Publish container image with source and compiled binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set the IMAGE_TAG environment variable
+        if: inputs.skip_base_v8 == false
+        run: |
+          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/javet-linux-dev:base-v8-${{ env.JAVET_V8_VERSION }}' >> $GITHUB_ENV
+
+      - name: Login to Docker Hub
+        if: inputs.skip_base_v8 == false
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Checkout the code
+        if: inputs.skip_base_v8 == false
+        uses: actions/checkout@v3
+
+      - name: Build docker image
+        if: inputs.skip_base_v8 == false
+        run: |
+          echo 'IMAGE_TAG is ${{ env.IMAGE_TAG }}'
+          docker build \
+            -t ${{ env.IMAGE_TAG }} \
+            --build-arg JAVET_V8_VERSION=${{ env.JAVET_V8_VERSION }} \
+            -f docker/linux-x86_64/base-v8.Dockerfile .
+
+      - name: Publish the docker image
+        if: inputs.skip_base_v8 == false
+        run: |
+          docker push ${{ env.IMAGE_TAG }}
+
+  publish_base_node:
+    needs: [publish_base_jvm]
+    name: Node.js - Publish container image with source and compiled binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set the IMAGE_TAG environment variable
+        if: inputs.skip_base_node == false
+        run: |
+          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/javet-linux-dev:base-node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
+
+      - name: Login to Docker Hub
+        if: inputs.skip_base_node == false
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Checkout the code
+        if: inputs.skip_base_node == false
+        uses: actions/checkout@v3
+
+      - name: Build docker image
+        if: inputs.skip_base_node == false
+        run: |
+          echo 'IMAGE_TAG is ${{ env.IMAGE_TAG }}'
+          docker build \
+            -t ${{ env.IMAGE_TAG }} \
+            --build-arg JAVET_NODE_VERSION=${{ env.JAVET_NODE_VERSION }} \
+            -f docker/linux-x86_64/base-node.Dockerfile .
+
+      - name: Publish the docker image
+        if: inputs.skip_base_node == false
+        run: |
+          docker push ${{ env.IMAGE_TAG }}
+
+  publish_v8_node:
+    needs: [publish_base_v8, publish_base_node]
+    name: V8 and Node.js - Publish container image with V8 source and binaries and Node.js source and binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set the IMAGE_TAG environment variable
+        run: |
+          echo 'IMAGE_TAG=${{ env.DOCKERHUB_USERNAME }}/javet-linux-dev:v8-${{ env.JAVET_V8_VERSION }}_node-${{ env.JAVET_NODE_VERSION }}' >> $GITHUB_ENV
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a
+        with:
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Build docker image
+        run: |
+          echo 'IMAGE_TAG is ${{ env.IMAGE_TAG }}'
+          docker build \
+            -t ${{ env.IMAGE_TAG }} \
+            --build-arg JAVET_V8_VERSION=${{ env.JAVET_V8_VERSION }} \
+            --build-arg JAVET_NODE_VERSION=${{ env.JAVET_NODE_VERSION }} \
+            -f docker/linux-x86_64/v8_node.Dockerfile .
+
+      - name: Publish the docker image
+        run: |
+          docker push ${{ env.IMAGE_TAG }}

--- a/docker/linux-x86_64/artifact.Dockerfile
+++ b/docker/linux-x86_64/artifact.Dockerfile
@@ -1,0 +1,28 @@
+# Copyright (c) 2021 caoccao.com Sam Cao
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: docker build \
+#  -t javet-local \
+#  --build-arg JAVET_GRADLE_IMAGE_TAG=amithgeorge/javet-linux-dev:2.0.1 \
+#  -f docker/linux-x86_64/artifact.Dockerfile .
+
+ARG JAVET_GRADLE_IMAGE_TAG=amithgeorge/javet-linux-dev:2.0.1
+FROM $JAVET_GRADLE_IMAGE_TAG
+
+WORKDIR /Javet
+COPY . .
+
+RUN scripts/shell/build_javet_artifacts.sh
+

--- a/docker/linux-x86_64/artifact.Dockerfile
+++ b/docker/linux-x86_64/artifact.Dockerfile
@@ -15,10 +15,10 @@
 
 # Usage: docker build \
 #  -t javet-local \
-#  --build-arg JAVET_GRADLE_IMAGE_TAG=amithgeorge/javet-linux-dev:2.0.1 \
+#  --build-arg JAVET_GRADLE_IMAGE_TAG=sjtucaocao/javet-linux-dev:2.0.1 \
 #  -f docker/linux-x86_64/artifact.Dockerfile .
 
-ARG JAVET_GRADLE_IMAGE_TAG=amithgeorge/javet-linux-dev:2.0.1
+ARG JAVET_GRADLE_IMAGE_TAG=sjtucaocao/javet-linux-dev:2.0.1
 FROM $JAVET_GRADLE_IMAGE_TAG
 
 WORKDIR /Javet

--- a/docker/linux-x86_64/artifact.Dockerfile
+++ b/docker/linux-x86_64/artifact.Dockerfile
@@ -15,10 +15,10 @@
 
 # Usage: docker build \
 #  -t javet-local \
-#  --build-arg JAVET_GRADLE_IMAGE_TAG=sjtucaocao/javet-linux-dev:2.0.1 \
+#  --build-arg JAVET_GRADLE_IMAGE_TAG=sjtucaocao/javet:x86_64-2.0.1 \
 #  -f docker/linux-x86_64/artifact.Dockerfile .
 
-ARG JAVET_GRADLE_IMAGE_TAG=sjtucaocao/javet-linux-dev:2.0.1
+ARG JAVET_GRADLE_IMAGE_TAG=sjtucaocao/javet:x86_64-2.0.1
 FROM $JAVET_GRADLE_IMAGE_TAG
 
 WORKDIR /Javet

--- a/docker/linux-x86_64/base-jvm.Dockerfile
+++ b/docker/linux-x86_64/base-jvm.Dockerfile
@@ -1,0 +1,56 @@
+# Copyright (c) 2021 caoccao.com Sam Cao
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: docker build -t amithgeorge/javet-linux-dev:base-jvm-latest -f docker/linux-x86_64/base-jvm.Dockerfile .
+
+FROM ubuntu:20.04
+WORKDIR /
+
+# Update Ubuntu
+ENV DEBIAN_FRONTEND=noninteractive
+# files need to be cleaned/deleted in the same RUN layer that adds them, else there is no actual size reduction benefit
+# the files remain in the image, just the layer marks the file as deleted and is not visible inside the OS
+RUN apt-get update --yes \
+	&& apt-get install --upgrade -qq --yes --no-install-recommends \
+	build-essential cmake curl execstack git maven openjdk-8-jdk \
+	patchelf python3 python python3-pip python3-distutils python3-testresources \
+	software-properties-common sudo unzip wget zip \
+	&& apt-get upgrade --yes \
+	&& pip3 install --no-cache-dir coloredlogs \
+	&& apt-get clean --yes
+
+# Install CMake
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.21.4/cmake-3.21.4-linux-x86_64.sh \
+	&& chmod 755 cmake-3.21.4-linux-x86_64.sh \
+	&& mkdir -p /usr/lib/cmake \
+	&& ./cmake-3.21.4-linux-x86_64.sh --skip-license --exclude-subdir --prefix=/usr/lib/cmake \
+	&& ln -sf /usr/lib/cmake/bin/cmake /usr/bin/cmake \
+	&& ln -sf /usr/lib/cmake/bin/cmake /bin/cmake \
+	&& rm cmake-3.21.4-linux-x86_64.sh
+
+# Prepare Javet Build Environment
+ENV JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+ENV SDKMAN_HOME="/root/.sdkman"
+ENV GRADLE_HOME="${SDKMAN_HOME}/candidates/gradle/current"
+ENV PATH=$GRADLE_HOME/bin:$PATH
+
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+# these two commands need to be on separate lines, else the symlink created above is not visible to the commands run below.
+# if the two RUN commmands are merged, we get the error "source: not found"
+RUN curl -s https://get.sdkman.io | bash \
+	&& source ${SDKMAN_HOME}/bin/sdkman-init.sh \
+	&& sdk install gradle 7.2 \
+	&& rm -rf ${SDKMAN_HOME}/archives/* \
+	&& rm -rf ${SDKMAN_HOME}/tmp/*

--- a/docker/linux-x86_64/base-jvm.Dockerfile
+++ b/docker/linux-x86_64/base-jvm.Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Usage: docker build -t sjtucaocao/javet:base-jvm-latest -f docker/linux-x86_64/base-jvm.Dockerfile .
+# Usage: docker build -t sjtucaocao/javet:x86_64-base-jvm-latest -f docker/linux-x86_64/base-jvm.Dockerfile .
 
 FROM ubuntu:20.04
 WORKDIR /

--- a/docker/linux-x86_64/base-jvm.Dockerfile
+++ b/docker/linux-x86_64/base-jvm.Dockerfile
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Usage: docker build -t amithgeorge/javet-linux-dev:base-jvm-latest -f docker/linux-x86_64/base-jvm.Dockerfile .
+# Usage: docker build -t sjtucaocao/javet:base-jvm-latest -f docker/linux-x86_64/base-jvm.Dockerfile .
 
 FROM ubuntu:20.04
 WORKDIR /

--- a/docker/linux-x86_64/base-node.Dockerfile
+++ b/docker/linux-x86_64/base-node.Dockerfile
@@ -1,0 +1,35 @@
+# Copyright (c) 2021 caoccao.com Sam Cao
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: docker build \
+#  -t amithgeorge/javet-linux-dev:base-node-18.12.0 \
+#  --build-arg JAVET_NODE_VERSION=18.12.0 \
+#  -f docker/linux-x86_64/base-node.Dockerfile .
+
+FROM amithgeorge/javet-linux-dev:base-jvm-latest
+
+ARG JAVET_NODE_VERSION=18.12.0
+RUN if [ -z "$JAVET_NODE_VERSION" ]; then echo 'Build argument JAVET_NODE_VERSION must be specified. Exiting.'; exit 1; fi
+
+# Prepare Node.js v18
+WORKDIR /
+COPY ./scripts/shell/fetch_node_source.sh .
+RUN bash ./fetch_node_source.sh
+
+# Build Node.js
+WORKDIR /node
+COPY ./scripts/python/patch_node_build.py .
+COPY ./scripts/shell/build_node_source.sh .
+RUN bash ./build_node_source.sh

--- a/docker/linux-x86_64/base-node.Dockerfile
+++ b/docker/linux-x86_64/base-node.Dockerfile
@@ -15,12 +15,15 @@
 
 # Usage: docker build \
 #  -t sjtucaocao/javet:x86_64-base-node-18.12.0 \
+#  --build-arg JAVET_REPO=sjtucaocao/javet \
 #  --build-arg JAVET_NODE_VERSION=18.12.0 \
 #  -f docker/linux-x86_64/base-node.Dockerfile .
 
-FROM sjtucaocao/javet:x86_64-base-jvm-latest
-
+ARG JAVET_REPO=sjtucaocao/javet
 ARG JAVET_NODE_VERSION=18.12.0
+FROM ${JAVET_REPO}:x86_64-base-jvm-latest
+
+ARG JAVET_NODE_VERSION
 RUN if [ -z "$JAVET_NODE_VERSION" ]; then echo 'Build argument JAVET_NODE_VERSION must be specified. Exiting.'; exit 1; fi
 
 # Prepare Node.js v18

--- a/docker/linux-x86_64/base-node.Dockerfile
+++ b/docker/linux-x86_64/base-node.Dockerfile
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 # Usage: docker build \
-#  -t amithgeorge/javet-linux-dev:base-node-18.12.0 \
+#  -t sjtucaocao/javet:base-node-18.12.0 \
 #  --build-arg JAVET_NODE_VERSION=18.12.0 \
 #  -f docker/linux-x86_64/base-node.Dockerfile .
 
-FROM amithgeorge/javet-linux-dev:base-jvm-latest
+FROM sjtucaocao/javet:base-jvm-latest
 
 ARG JAVET_NODE_VERSION=18.12.0
 RUN if [ -z "$JAVET_NODE_VERSION" ]; then echo 'Build argument JAVET_NODE_VERSION must be specified. Exiting.'; exit 1; fi

--- a/docker/linux-x86_64/base-node.Dockerfile
+++ b/docker/linux-x86_64/base-node.Dockerfile
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 # Usage: docker build \
-#  -t sjtucaocao/javet:base-node-18.12.0 \
+#  -t sjtucaocao/javet:x86_64-base-node-18.12.0 \
 #  --build-arg JAVET_NODE_VERSION=18.12.0 \
 #  -f docker/linux-x86_64/base-node.Dockerfile .
 
-FROM sjtucaocao/javet:base-jvm-latest
+FROM sjtucaocao/javet:x86_64-base-jvm-latest
 
 ARG JAVET_NODE_VERSION=18.12.0
 RUN if [ -z "$JAVET_NODE_VERSION" ]; then echo 'Build argument JAVET_NODE_VERSION must be specified. Exiting.'; exit 1; fi

--- a/docker/linux-x86_64/base-v8.Dockerfile
+++ b/docker/linux-x86_64/base-v8.Dockerfile
@@ -15,12 +15,15 @@
 
 # Usage: docker build \
 #  -t sjtucaocao/javet:x86_64-base-v8-10.7.193.16 \
+#  --build-arg JAVET_REPO=sjtucaocao/javet \
 #  --build-arg JAVET_V8_VERSION=10.7.193.16 \
 #  -f docker/linux-x86_64/base-v8.Dockerfile .
 
-FROM sjtucaocao/javet:x86_64-base-jvm-latest
-
+ARG JAVET_REPO=sjtucaocao/javet
 ARG JAVET_V8_VERSION=10.7.193.16
+FROM ${JAVET_REPO}:x86_64-base-jvm-latest
+
+ARG JAVET_V8_VERSION
 RUN if [ -z "$JAVET_V8_VERSION" ]; then echo 'Build argument JAVET_V8_VERSION must be specified. Exiting.'; exit 1; fi
 
 # Prepare V8

--- a/docker/linux-x86_64/base-v8.Dockerfile
+++ b/docker/linux-x86_64/base-v8.Dockerfile
@@ -1,0 +1,37 @@
+# Copyright (c) 2021 caoccao.com Sam Cao
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: docker build \
+#  -t amithgeorge/javet-linux-dev:base-v8-10.7.193.16 \
+#  --build-arg JAVET_V8_VERSION=10.7.193.16 \
+#  -f docker/linux-x86_64/base-v8.Dockerfile .
+
+FROM amithgeorge/javet-linux-dev:base-jvm-latest
+
+ARG JAVET_V8_VERSION=10.7.193.16
+RUN if [ -z "$JAVET_V8_VERSION" ]; then echo 'Build argument JAVET_V8_VERSION must be specified. Exiting.'; exit 1; fi
+
+# Prepare V8
+WORKDIR /google
+ENV DEPOT_TOOLS_UPDATE=0
+ENV PATH=/google/depot_tools:$PATH
+COPY ./scripts/shell/fetch_v8_source.sh .
+RUN bash fetch_v8_source.sh
+
+# Build V8
+WORKDIR /google/v8
+COPY ./scripts/python/patch_v8_build.py .
+COPY ./scripts/shell/build_v8_source.sh .
+RUN bash ./build_v8_source.sh

--- a/docker/linux-x86_64/base-v8.Dockerfile
+++ b/docker/linux-x86_64/base-v8.Dockerfile
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 # Usage: docker build \
-#  -t amithgeorge/javet-linux-dev:base-v8-10.7.193.16 \
+#  -t sjtucaocao/javet:base-v8-10.7.193.16 \
 #  --build-arg JAVET_V8_VERSION=10.7.193.16 \
 #  -f docker/linux-x86_64/base-v8.Dockerfile .
 
-FROM amithgeorge/javet-linux-dev:base-jvm-latest
+FROM sjtucaocao/javet:base-jvm-latest
 
 ARG JAVET_V8_VERSION=10.7.193.16
 RUN if [ -z "$JAVET_V8_VERSION" ]; then echo 'Build argument JAVET_V8_VERSION must be specified. Exiting.'; exit 1; fi

--- a/docker/linux-x86_64/base-v8.Dockerfile
+++ b/docker/linux-x86_64/base-v8.Dockerfile
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 # Usage: docker build \
-#  -t sjtucaocao/javet:base-v8-10.7.193.16 \
+#  -t sjtucaocao/javet:x86_64-base-v8-10.7.193.16 \
 #  --build-arg JAVET_V8_VERSION=10.7.193.16 \
 #  -f docker/linux-x86_64/base-v8.Dockerfile .
 
-FROM sjtucaocao/javet:base-jvm-latest
+FROM sjtucaocao/javet:x86_64-base-jvm-latest
 
 ARG JAVET_V8_VERSION=10.7.193.16
 RUN if [ -z "$JAVET_V8_VERSION" ]; then echo 'Build argument JAVET_V8_VERSION must be specified. Exiting.'; exit 1; fi

--- a/docker/linux-x86_64/gradle.Dockerfile
+++ b/docker/linux-x86_64/gradle.Dockerfile
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 # Usage: docker build \
-#  -t amithgeorge/javet-linux-dev:2.0.1 \
-#  --build-arg JAVET_V8_NODE_IMAGE_TAG=amithgeorge/javet-linux-dev:v8-10.7.193.16_node-18.12.0 \
+#  -t sjtucaocao/javet:2.0.1 \
+#  --build-arg JAVET_V8_NODE_IMAGE_TAG=sjtucaocao/javet:v8-10.7.193.16_node-18.12.0 \
 #  -f docker/linux-x86_64/gradle.Dockerfile .
 
-ARG JAVET_V8_NODE_IMAGE_TAG=amithgeorge/javet-linux-dev:v8-10.7.193.16_node-18.12.0
+ARG JAVET_V8_NODE_IMAGE_TAG=sjtucaocao/javet:v8-10.7.193.16_node-18.12.0
 FROM $JAVET_V8_NODE_IMAGE_TAG
 
 WORKDIR /Javet

--- a/docker/linux-x86_64/gradle.Dockerfile
+++ b/docker/linux-x86_64/gradle.Dockerfile
@@ -14,11 +14,11 @@
 # limitations under the License.
 
 # Usage: docker build \
-#  -t sjtucaocao/javet:2.0.1 \
-#  --build-arg JAVET_V8_NODE_IMAGE_TAG=sjtucaocao/javet:v8-10.7.193.16_node-18.12.0 \
+#  -t sjtucaocao/javet:x86_64-2.0.1 \
+#  --build-arg JAVET_V8_NODE_IMAGE_TAG=sjtucaocao/javet:x86_64-v8-10.7.193.16_node-18.12.0 \
 #  -f docker/linux-x86_64/gradle.Dockerfile .
 
-ARG JAVET_V8_NODE_IMAGE_TAG=sjtucaocao/javet:v8-10.7.193.16_node-18.12.0
+ARG JAVET_V8_NODE_IMAGE_TAG=sjtucaocao/javet:x86_64-v8-10.7.193.16_node-18.12.0
 FROM $JAVET_V8_NODE_IMAGE_TAG
 
 WORKDIR /Javet

--- a/docker/linux-x86_64/gradle.Dockerfile
+++ b/docker/linux-x86_64/gradle.Dockerfile
@@ -1,0 +1,26 @@
+# Copyright (c) 2021 caoccao.com Sam Cao
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: docker build \
+#  -t amithgeorge/javet-linux-dev:2.0.1 \
+#  --build-arg JAVET_V8_NODE_IMAGE_TAG=amithgeorge/javet-linux-dev:v8-10.7.193.16_node-18.12.0 \
+#  -f docker/linux-x86_64/gradle.Dockerfile .
+
+ARG JAVET_V8_NODE_IMAGE_TAG=amithgeorge/javet-linux-dev:v8-10.7.193.16_node-18.12.0
+FROM $JAVET_V8_NODE_IMAGE_TAG
+
+WORKDIR /Javet
+COPY . .
+RUN gradle dependencies && cd / && rm -rf /Javet

--- a/docker/linux-x86_64/v8_node.Dockerfile
+++ b/docker/linux-x86_64/v8_node.Dockerfile
@@ -14,24 +14,24 @@
 # limitations under the License.
 
 # Usage: docker build \
-#  -t amithgeorge/javet-linux-dev:v8-10.7.193.16_node-18.12.0 \
+#  -t sjtucaocao/javet:v8-10.7.193.16_node-18.12.0 \
 #  -f docker/linux-x86_64/base-node.Dockerfile .
 
 ARG JAVET_V8_VERSION=10.7.193.16
 ARG JAVET_NODE_VERSION=18.12.0
-FROM amithgeorge/javet-linux-dev:base-v8-$JAVET_V8_VERSION as base-v8
+FROM sjtucaocao/javet:base-v8-$JAVET_V8_VERSION as base-v8
 
 # the ARG JAVET_NODE_VERSION needs to be declared twice due to how Dockerfile treats ARG and FROM
 # Reference - https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG JAVET_NODE_VERSION
-FROM amithgeorge/javet-linux-dev:base-node-$JAVET_NODE_VERSION as base-node
+FROM sjtucaocao/javet:base-node-$JAVET_NODE_VERSION as base-node
 
 # we could base the final image off the `base-v8` image, that would save us time copying the /google folder
 # however, the resulting image is almost 1GB bigger than using base-jvm as the base
 # for now, we will optimize for getting a smaller image
 
 # final image
-FROM amithgeorge/javet-linux-dev:base-jvm-latest
+FROM sjtucaocao/javet:base-jvm-latest
 
 RUN mkdir -p /google && mkdir -p /node
 COPY --from=base-v8 /google /google

--- a/docker/linux-x86_64/v8_node.Dockerfile
+++ b/docker/linux-x86_64/v8_node.Dockerfile
@@ -1,0 +1,40 @@
+# Copyright (c) 2021 caoccao.com Sam Cao
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Usage: docker build \
+#  -t amithgeorge/javet-linux-dev:v8-10.7.193.16_node-18.12.0 \
+#  -f docker/linux-x86_64/base-node.Dockerfile .
+
+ARG JAVET_V8_VERSION=10.7.193.16
+ARG JAVET_NODE_VERSION=18.12.0
+FROM amithgeorge/javet-linux-dev:base-v8-$JAVET_V8_VERSION as base-v8
+
+# the ARG JAVET_NODE_VERSION needs to be declared twice due to how Dockerfile treats ARG and FROM
+# Reference - https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG JAVET_NODE_VERSION
+FROM amithgeorge/javet-linux-dev:base-node-$JAVET_NODE_VERSION as base-node
+
+# we could base the final image off the `base-v8` image, that would save us time copying the /google folder
+# however, the resulting image is almost 1GB bigger than using base-jvm as the base
+# for now, we will optimize for getting a smaller image
+
+# final image
+FROM amithgeorge/javet-linux-dev:base-jvm-latest
+
+RUN mkdir -p /google && mkdir -p /node
+COPY --from=base-v8 /google /google
+COPY --from=base-node /node /node
+
+WORKDIR /Javet

--- a/docker/linux-x86_64/v8_node.Dockerfile
+++ b/docker/linux-x86_64/v8_node.Dockerfile
@@ -14,24 +14,24 @@
 # limitations under the License.
 
 # Usage: docker build \
-#  -t sjtucaocao/javet:v8-10.7.193.16_node-18.12.0 \
+#  -t sjtucaocao/javet:x86_64-v8-10.7.193.16_node-18.12.0 \
 #  -f docker/linux-x86_64/base-node.Dockerfile .
 
 ARG JAVET_V8_VERSION=10.7.193.16
 ARG JAVET_NODE_VERSION=18.12.0
-FROM sjtucaocao/javet:base-v8-$JAVET_V8_VERSION as base-v8
+FROM sjtucaocao/javet:x86_64-base-v8-$JAVET_V8_VERSION as base-v8
 
 # the ARG JAVET_NODE_VERSION needs to be declared twice due to how Dockerfile treats ARG and FROM
 # Reference - https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG JAVET_NODE_VERSION
-FROM sjtucaocao/javet:base-node-$JAVET_NODE_VERSION as base-node
+FROM sjtucaocao/javet:x86_64-base-node-$JAVET_NODE_VERSION as base-node
 
 # we could base the final image off the `base-v8` image, that would save us time copying the /google folder
 # however, the resulting image is almost 1GB bigger than using base-jvm as the base
 # for now, we will optimize for getting a smaller image
 
 # final image
-FROM sjtucaocao/javet:base-jvm-latest
+FROM sjtucaocao/javet:x86_64-base-jvm-latest
 
 RUN mkdir -p /google && mkdir -p /node
 COPY --from=base-v8 /google /google

--- a/docker/linux-x86_64/v8_node.Dockerfile
+++ b/docker/linux-x86_64/v8_node.Dockerfile
@@ -15,23 +15,27 @@
 
 # Usage: docker build \
 #  -t sjtucaocao/javet:x86_64-v8-10.7.193.16_node-18.12.0 \
+#  --build-arg JAVET_REPO=sjtucaocao/javet \
 #  -f docker/linux-x86_64/base-node.Dockerfile .
 
+ARG JAVET_REPO=sjtucaocao/javet
 ARG JAVET_V8_VERSION=10.7.193.16
 ARG JAVET_NODE_VERSION=18.12.0
-FROM sjtucaocao/javet:x86_64-base-v8-$JAVET_V8_VERSION as base-v8
+FROM ${JAVET_REPO}:x86_64-base-v8-$JAVET_V8_VERSION as base-v8
 
 # the ARG JAVET_NODE_VERSION needs to be declared twice due to how Dockerfile treats ARG and FROM
 # Reference - https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
+ARG JAVET_REPO
 ARG JAVET_NODE_VERSION
-FROM sjtucaocao/javet:x86_64-base-node-$JAVET_NODE_VERSION as base-node
+FROM ${JAVET_REPO}:x86_64-base-node-$JAVET_NODE_VERSION as base-node
 
 # we could base the final image off the `base-v8` image, that would save us time copying the /google folder
 # however, the resulting image is almost 1GB bigger than using base-jvm as the base
 # for now, we will optimize for getting a smaller image
 
 # final image
-FROM sjtucaocao/javet:x86_64-base-jvm-latest
+ARG JAVET_REPO
+FROM ${JAVET_REPO}:x86_64-base-jvm-latest
 
 RUN mkdir -p /google && mkdir -p /node
 COPY --from=base-v8 /google /google

--- a/docs/development/build_javet_with_docker.rst
+++ b/docs/development/build_javet_with_docker.rst
@@ -36,7 +36,7 @@ Build Javet for Linux on Linux or Windows
 
     git clone https://github.com/caoccao/Javet.git
     cd Javet
-    docker build -f docker/linux-x86_64/build.Dockerfile .
+    docker build -f docker/linux-x86_64/artifact.Dockerfile .
 
 .. note::
 

--- a/scripts/shell/build_javet_artifacts.sh
+++ b/scripts/shell/build_javet_artifacts.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+pushd /Javet/cpp
+sh ./build-linux.sh -DV8_DIR=/google/v8
+sh ./build-linux.sh -DNODE_DIR=/node
+popd
+
+touch src/main/resources/libjavet-v8*
+gradle build test --rerun-tasks --debug
+# gradle build test --rerun-tasks
+
+touch src/main/resources/libjavet-node*
+gradle test --rerun-tasks --debug
+# gradle test --rerun-tasks

--- a/scripts/shell/build_node_source.sh
+++ b/scripts/shell/build_node_source.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+build_node(){
+	python3 patch_node_build.py -p ./
+	./configure --enable-static --without-intl
+	python3 patch_node_build.py -p ./
+	rm patch_node_build.py
+	make -j4
+	echo "Node.js build is completed"
+}
+
+build_node

--- a/scripts/shell/build_v8_source.sh
+++ b/scripts/shell/build_v8_source.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+build_v8(){
+  python3 tools/dev/v8gen.py x64.release -- \
+    v8_monolithic=true v8_use_external_startup_data=false is_component_build=false v8_enable_i18n_support=false \
+    v8_enable_pointer_compression=false v8_static_library=true symbol_level=0 \
+    use_custom_libcxx=false v8_enable_sandbox=false
+
+  ninja -C out.gn/x64.release v8_monolith || python3 patch_v8_build.py -p ./
+  ninja -C out.gn/x64.release v8_monolith
+  rm patch_v8_build.py
+  echo "V8 build is completed"
+}
+
+build_v8

--- a/scripts/shell/fetch_node_source.sh
+++ b/scripts/shell/fetch_node_source.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+fetch_node_source() {
+  git clone --depth=1 --branch=v${JAVET_NODE_VERSION} https://github.com/nodejs/node.git
+  echo "Node.js source fetched"
+}
+
+fetch_node_source

--- a/scripts/shell/fetch_v8_source.sh
+++ b/scripts/shell/fetch_v8_source.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+fetch_depot_tools() {
+  git clone --depth=10 --branch=main https://chromium.googlesource.com/chromium/tools/depot_tools.git
+  pushd depot_tools
+  git checkout remotes/origin/main
+  popd
+}
+
+fetch_v8_source() {
+  # reference - https://stackoverflow.com/a/47093174/30007
+  mkdir v8
+
+  pushd v8
+  git init . &&
+  git fetch https://chromium.googlesource.com/v8/v8.git +refs/tags/${JAVET_V8_VERSION}:v8_${JAVET_V8_VERSION} --depth 1
+  git checkout tags/${JAVET_V8_VERSION}
+  popd
+
+  gclient root
+  gclient config --spec 'solutions = [{"name": "v8","url": "https://chromium.googlesource.com/v8/v8.git","deps_file": "DEPS","managed": False,"custom_deps": {},},]'
+  gclient sync --no-history
+  gclient runhooks
+
+  pushd v8
+  sed -i 's/snapcraft/nosnapcraft/g' ./build/install-build-deps.sh
+  ./build/install-build-deps.sh
+  sed -i 's/nosnapcraft/snapcraft/g' ./build/install-build-deps.sh
+  popd
+
+  gclient sync --no-history
+  echo "V8 source fetched"
+}
+
+fetch_depot_tools
+fetch_v8_source


### PR DESCRIPTION
Original PR discussion - https://github.com/caoccao/Javet/pull/197
Original Issue - https://github.com/caoccao/Javet/issues/171

I accidentally closed the previous PR. I have incorporated the changes as suggested on the previous PR. Please have a look. 

- Successful execution of workflow for building the base image - https://github.com/amithgeorge/Javet/actions/runs/3428737410

- Successful execution of workflow for building the image with grade deps - https://github.com/amithgeorge/Javet/actions/runs/3428737387

- Successful execution of workflow for building the artifact - https://github.com/amithgeorge/Javet/actions/runs/3428737407

Things that need to be updated

- [x] Docker Hub user name
- [x] Docker Hub repo name
- [ ] Instructions for which all variables need to be updated in the various build files

-----

In the repository, create three Repository level Action Secrets 
- `DOCKERHUB_USERNAME` 
- `DOCKERHUB_ACCESS_TOKEN` : the [Personal Access Token](https://docs.docker.com/docker-hub/access-tokens/) for the above mentioned user
- `DOCKERHUB_REPO_JAVET`: the name of the docker hub repository to which the images should be pushed. Must be owned by the above mentioned user. 

-----

When we need to update the version of either V8 or Node.js, or update the Javet artifact version, then make changes to the following files 

.github/workflows/linux_build_node_v8_image.yml
  - env JAVET_V8_VERSION
  - env JAVET_NODE_VERSION

.github/workflows/linux_build_dev_image.yml
  - env JAVET_V8_NODE_IMAGE_TAG
  - env JAVET_VERSION

.github/workflows/linux_build_artifact.yml
  - env JAVET_GRADLE_IMAGE_TAG

docker/linux-x86_64/base-v8.Dockerfile
  - ARG JAVET_V8_VERSION
  - version in Usage comment

docker/linux-x86_64/base-node.Dockerfile
  - ARG JAVET_NODE_VERSION
  - version in Usage comment

docker/linux-x86_64/v8_node.Dockerfile
  - ARG JAVET_V8_VERSION
  - ARG JAVET_NODE_VERSION
  - version in Usage comment

docker/linux-x86_64/gradle.Dockerfile
  - ARG JAVET_V8_NODE_IMAGE_TAG
  - version in Usage comment

docker/linux-x86_64/artifact.Dockerfile
  - ARG JAVET_GRADLE_IMAGE_TAG
  - version in Usage comment 

