### PR TITLE
Fix errors during the docker build process

### DIFF
--- a/docker/linux-x86_64/base_all_in_one.Dockerfile
+++ b/docker/linux-x86_64/base_all_in_one.Dockerfile
@@ -39,22 +39,22 @@ RUN ln -sf /usr/lib/cmake/bin/cmake /bin/cmake
 RUN rm cmake-3.25.1-linux-x86_64.sh
 
 # Prepare V8
-RUN mkdir google
-WORKDIR /google
-RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-WORKDIR /google/depot_tools
-RUN git checkout remotes/origin/main
+RUN mkdir -p /google/depot_tools && \
+    git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /google/depot_tools && \
+    cd /google/depot_tools && \
+    git checkout remotes/origin/main && \
+    export PATH=/google/depot_tools:$PATH && \
+    cd /google && \
+    fetch v8 && \
+    cd /google/v8 && \
+    git checkout ${JAVET_V8_VERSION} && \
+    sed -i 's/snapcraft/nosnapcraft/g' ./build/install-build-deps.sh && \
+    ./build/install-build-deps.sh && \
+    sed -i 's/nosnapcraft/snapcraft/g' ./build/install-build-deps.sh && \
+    cd /google && \
+    gclient sync && \
+    echo V8 preparation is completed.
 ENV PATH=/google/depot_tools:$PATH
-WORKDIR /google
-RUN fetch v8
-WORKDIR /google/v8
-RUN git checkout ${JAVET_V8_VERSION}
-RUN sed -i 's/snapcraft/nosnapcraft/g' ./build/install-build-deps.sh
-RUN ./build/install-build-deps.sh
-RUN sed -i 's/nosnapcraft/snapcraft/g' ./build/install-build-deps.sh
-WORKDIR /google
-RUN gclient sync
-RUN echo V8 preparation is completed.
 
 # Build V8
 WORKDIR /google/v8

--- a/docker/linux-x86_64/base_all_in_one.Dockerfile
+++ b/docker/linux-x86_64/base_all_in_one.Dockerfile
@@ -15,11 +15,11 @@
 
 # Usage: docker build -t sjtucaocao/javet:3.1.1 -f docker/linux-x86_64/base_all_in_one.Dockerfile .
 
-ARG JAVET_NODE_VERSION=20.12.2
-ARG JAVET_V8_VERSION=12.4.254.9
-
 FROM ubuntu:20.04
 WORKDIR /
+
+ARG JAVET_NODE_VERSION=20.12.2
+ARG JAVET_V8_VERSION=12.4.254.9
 
 # Update Ubuntu
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker/linux-x86_64/base_all_in_one.Dockerfile
+++ b/docker/linux-x86_64/base_all_in_one.Dockerfile
@@ -24,7 +24,7 @@ ARG JAVET_V8_VERSION=12.4.254.9
 # Update Ubuntu
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get install --upgrade -qq -y --no-install-recommends git curl wget build-essential software-properties-common patchelf maven sudo zip unzip execstack cmake
+RUN apt-get install --upgrade -qq -y --no-install-recommends git curl wget build-essential software-properties-common patchelf maven sudo zip unzip execstack cmake file keyboard-configuration
 RUN apt-get install --upgrade -qq -y --no-install-recommends python3 python python3-pip python3-distutils python3-testresources
 RUN apt-get upgrade -y
 RUN pip3 install coloredlogs


### PR DESCRIPTION
1. **The `file` and `keyboard-configuration` packages are required, or the execution of `./build/install-build-deps.sh` will break**

To reproduce, run the following command:
```
docker build -t sjtucaocao/javet:3.1.1 -f docker/linux-x86_64/base_all_in_one.Dockerfile .
```

Error message:
```
------
 > [24/65] RUN ./build/install-build-deps.sh:
1.015 Hit:1 http://archive.ubuntu.com/ubuntu focal InRelease
1.189 Hit:2 http://security.ubuntu.com/ubuntu focal-security InRelease
1.349 Hit:3 http://archive.ubuntu.com/ubuntu focal-updates InRelease
1.603 Hit:4 http://archive.ubuntu.com/ubuntu focal-backports InRelease
1.650 Reading package lists...
3.464 Finding missing packages...
3.464 Building apt package list.
3.466 Traceback (most recent call last):
3.466   File "/google/v8/build/install-build-deps.py", line 947, in <module>
3.466     sys.exit(main())
3.466   File "/google/v8/build/install-build-deps.py", line 940, in main
3.466     install_packages(options)
3.466   File "/google/v8/build/install-build-deps.py", line 852, in install_packages
3.466     packages = find_missing_packages(options)
3.466   File "/google/v8/build/install-build-deps.py", line 826, in find_missing_packages
3.466     packages = package_list(options)
3.466   File "/google/v8/build/install-build-deps.py", line 765, in package_list
3.466     packages = (dev_list() + lib_list() + dbg_list(options) +
3.466   File "/google/v8/build/install-build-deps.py", line 315, in dev_list
3.466     if "ELF 64-bit" in subprocess.check_output(["file", "-L",
3.466   File "/usr/lib/python3.8/subprocess.py", line 415, in check_output
3.466     return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
3.466   File "/usr/lib/python3.8/subprocess.py", line 493, in run
3.466     with Popen(*popenargs, **kwargs) as process:
3.466   File "/usr/lib/python3.8/subprocess.py", line 858, in __init__
3.466     self._execute_child(args, executable, preexec_fn, close_fds,
3.466   File "/usr/lib/python3.8/subprocess.py", line 1704, in _execute_child
3.466     raise child_exception_type(errno_num, err_msg, err_filename)
3.466 FileNotFoundError: [Errno 2] No such file or directory: 'file'
------
base_all_in_one.Dockerfile:53
--------------------
  51 |     RUN git checkout ${JAVET_V8_VERSION}
  52 |     RUN sed -i 's/snapcraft/nosnapcraft/g' ./build/install-build-deps.sh
  53 | >>> RUN ./build/install-build-deps.sh
  54 |     RUN sed -i 's/nosnapcraft/snapcraft/g' ./build/install-build-deps.sh
  55 |     WORKDIR /google
--------------------
ERROR: failed to solve: process "/bin/sh -c ./build/install-build-deps.sh" did not complete successfully: exit code: 1
```

2. **Fix the `invalid cross-device link` error during `gclient  sync`**

The `invalid cross-device link` error does not exist in the V8 `12.4.254.9` version, but exists in the previous `12.3.219.10` version.

To reproduce, run the following command:
```
docker build --build-arg JAVET_NODE_VERSION=20.11.1 --build-arg JAVET_V8_VERSION=12.3.219.10 -t sjtucaocao/javet:3.1.0 -f docker/linux-x86_64/base_all_in_one.Dockerfile .
```

Error message:
```
------                                                                                                                                                                                                                                     
 > [27/65] RUN gclient sync:                                                                                                                                                                                                               
78.42                                                                                                                                                                                                                                      
78.42 ________ running 'cipd ensure -log-level error -root /google -ensure-file /tmp/tmpqykeainl.ensure' in '.'                                                                                                                            
78.42 [P608 06:46:09.875 client.go:1915 E] [cleanup] Failed to remove infra/build/siso/linux-amd64 in "v8/third_party/siso": removing the deployed package directory: rename /google/.cipd/pkgs/3 /google/.cipd/pkgs/q0Gyd68etUGP: invalid cross-device link                                                                                                                                                                                                                          
78.42 Errors:
78.42   failed to remove infra/build/siso/linux-amd64 in "v8/third_party/siso": removing the deployed package directory: rename /google/.cipd/pkgs/3 /google/.cipd/pkgs/q0Gyd68etUGP: invalid cross-device link
78.42 Error: Command 'cipd ensure -log-level error -root /google -ensure-file /tmp/tmpqykeainl.ensure' returned non-zero exit status 1
78.42 [P608 06:46:09.875 client.go:1915 E] [cleanup] Failed to remove infra/build/siso/linux-amd64 in "v8/third_party/siso": removing the deployed package directory: rename /google/.cipd/pkgs/3 /google/.cipd/pkgs/q0Gyd68etUGP: invalid cross-device link
78.42 Errors:
78.42   failed to remove infra/build/siso/linux-amd64 in "v8/third_party/siso": removing the deployed package directory: rename /google/.cipd/pkgs/3 /google/.cipd/pkgs/q0Gyd68etUGP: invalid cross-device link
78.42 
------
base_all_in_one.Dockerfile:56
--------------------
  54 |     RUN sed -i 's/nosnapcraft/snapcraft/g' ./build/install-build-deps.sh
  55 |     WORKDIR /google
  56 | >>> RUN gclient sync
  57 |     RUN echo V8 preparation is completed.
  58 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c gclient sync" did not complete successfully: exit code: 1
```

Related discussion: https://github.com/caoccao/Javet/discussions/196
