### PR TITLE
解决eval问题

### DIFF
--- a/cpp/jni/javet_jni_core_v8.cpp
+++ b/cpp/jni/javet_jni_core_v8.cpp
@@ -23,7 +23,7 @@
   * 2. Methods are expected to be sorted alphabatically except JNI_OnLoad.
   */
 // Set a callback that disallows the code generation.
-ModifyCodeGenerationFromStringsResult CodeGenerationDisallowed(
+v8::ModifyCodeGenerationFromStringsResult CodeGenerationDisallowed(
     V8LocalContext context, V8LocalValue source, bool is_code_like) {
       return {false, {}};
 }

--- a/cpp/jni/javet_jni_core_v8.cpp
+++ b/cpp/jni/javet_jni_core_v8.cpp
@@ -28,20 +28,13 @@ ModifyCodeGenerationFromStringsResult CodeGenerationDisallowed(
       return {false, {}};
 }
 
-ModifyCodeGenerationFromStringsResult ModifyCodeGeneration(
-    V8LocalContext context, V8LocalValue source, bool is_code_like) {
-  // Allow (passthrough, unmodified) all objects that are not strings.
-  if (!source->IsString()) {
-    return {/* codegen_allowed= */ true, V8MaybeLocalString()};
-  }
-
 JNIEXPORT void JNICALL Java_com_caoccao_javet_interop_V8Native_allowCodeGenerationFromStrings
 (JNIEnv* jniEnv, jobject caller, jlong v8RuntimeHandle, jboolean allow) {
     RUNTIME_HANDLES_TO_OBJECTS_WITH_SCOPE(v8RuntimeHandle);
     v8Context->AllowCodeGenerationFromStrings(allow);
 #ifdef ENABLE_NODE
     if(!allow) {
-       v8Context->GetIsolate()->SetModifyCodeGenerationFromStringsCallback(&ModifyCodeGeneration);
+       v8Context->GetIsolate()->SetModifyCodeGenerationFromStringsCallback(&CodeGenerationDisallowed);
     }
 #endif
 }

--- a/cpp/jni/javet_jni_core_v8.cpp
+++ b/cpp/jni/javet_jni_core_v8.cpp
@@ -27,6 +27,9 @@ JNIEXPORT void JNICALL Java_com_caoccao_javet_interop_V8Native_allowCodeGenerati
 (JNIEnv* jniEnv, jobject caller, jlong v8RuntimeHandle, jboolean allow) {
     RUNTIME_HANDLES_TO_OBJECTS_WITH_SCOPE(v8RuntimeHandle);
     v8Context->AllowCodeGenerationFromStrings(allow);
+#ifdef ENABLE_NODE
+    v8Runtime->v8Isolate->SetModifyCodeGenerationFromStringsCallback(allow);
+#endif
 }
 
 JNIEXPORT jboolean JNICALL Java_com_caoccao_javet_interop_V8Native_await

--- a/cpp/jni/javet_jni_core_v8.cpp
+++ b/cpp/jni/javet_jni_core_v8.cpp
@@ -23,7 +23,7 @@
   * 2. Methods are expected to be sorted alphabatically except JNI_OnLoad.
   */
 // Set a callback that disallows the code generation.
-V8Runtime::ModifyCodeGenerationFromStringsResult CodeGenerationDisallowed(
+ModifyCodeGenerationFromStringsResult CodeGenerationDisallowed(
     Local<Context> context, Local<Value> source, bool is_code_like) {
       return {false, {}};
 }

--- a/cpp/jni/javet_jni_core_v8.cpp
+++ b/cpp/jni/javet_jni_core_v8.cpp
@@ -23,20 +23,19 @@
   * 2. Methods are expected to be sorted alphabatically except JNI_OnLoad.
   */
 // Set a callback that disallows the code generation.
-v8::ModifyCodeGenerationFromStringsResult CodeGenerationDisallowed(
-    V8LocalContext context, V8LocalValue source, bool is_code_like) {
+v8::ModifyCodeGenerationFromStringsResult CodeGenerationDisallowed(V8LocalContext context, V8LocalValue source, bool is_code_like) {
       return {false, {}};
 }
 
 JNIEXPORT void JNICALL Java_com_caoccao_javet_interop_V8Native_allowCodeGenerationFromStrings
 (JNIEnv* jniEnv, jobject caller, jlong v8RuntimeHandle, jboolean allow) {
     RUNTIME_HANDLES_TO_OBJECTS_WITH_SCOPE(v8RuntimeHandle);
-    v8Context->AllowCodeGenerationFromStrings(allow);
 #ifdef ENABLE_NODE
     if(!allow) {
        v8Context->GetIsolate()->SetModifyCodeGenerationFromStringsCallback(&CodeGenerationDisallowed);
     }
 #endif
+    v8Context->AllowCodeGenerationFromStrings(allow);
 }
 
 JNIEXPORT jboolean JNICALL Java_com_caoccao_javet_interop_V8Native_await

--- a/cpp/jni/javet_jni_core_v8.cpp
+++ b/cpp/jni/javet_jni_core_v8.cpp
@@ -22,13 +22,20 @@
   * 1. Omitting namespace is not recommended in this project.
   * 2. Methods are expected to be sorted alphabatically except JNI_OnLoad.
   */
+// Set a callback that disallows the code generation.
+V8Runtime::ModifyCodeGenerationFromStringsResult CodeGenerationDisallowed(
+    Local<Context> context, Local<Value> source, bool is_code_like) {
+      return {false, {}};
+}
 
 JNIEXPORT void JNICALL Java_com_caoccao_javet_interop_V8Native_allowCodeGenerationFromStrings
 (JNIEnv* jniEnv, jobject caller, jlong v8RuntimeHandle, jboolean allow) {
     RUNTIME_HANDLES_TO_OBJECTS_WITH_SCOPE(v8RuntimeHandle);
     v8Context->AllowCodeGenerationFromStrings(allow);
 #ifdef ENABLE_NODE
-    v8Runtime->v8Isolate->SetModifyCodeGenerationFromStringsCallback(allow);
+    if(!allow) {
+       v8Context->GetIsolate()->SetModifyCodeGenerationFromStringsCallback(&CodeGenerationDisallowed);
+    }
 #endif
 }
 

--- a/cpp/jni/javet_jni_core_v8.cpp
+++ b/cpp/jni/javet_jni_core_v8.cpp
@@ -24,9 +24,16 @@
   */
 // Set a callback that disallows the code generation.
 ModifyCodeGenerationFromStringsResult CodeGenerationDisallowed(
-    Local<Context> context, Local<Value> source, bool is_code_like) {
+    V8LocalContext context, V8LocalValue source, bool is_code_like) {
       return {false, {}};
 }
+
+ModifyCodeGenerationFromStringsResult ModifyCodeGeneration(
+    V8LocalContext context, V8LocalValue source, bool is_code_like) {
+  // Allow (passthrough, unmodified) all objects that are not strings.
+  if (!source->IsString()) {
+    return {/* codegen_allowed= */ true, V8MaybeLocalString()};
+  }
 
 JNIEXPORT void JNICALL Java_com_caoccao_javet_interop_V8Native_allowCodeGenerationFromStrings
 (JNIEnv* jniEnv, jobject caller, jlong v8RuntimeHandle, jboolean allow) {
@@ -34,7 +41,7 @@ JNIEXPORT void JNICALL Java_com_caoccao_javet_interop_V8Native_allowCodeGenerati
     v8Context->AllowCodeGenerationFromStrings(allow);
 #ifdef ENABLE_NODE
     if(!allow) {
-       v8Context->GetIsolate()->SetModifyCodeGenerationFromStringsCallback(&CodeGenerationDisallowed);
+       v8Context->GetIsolate()->SetModifyCodeGenerationFromStringsCallback(&ModifyCodeGeneration);
     }
 #endif
 }

--- a/cpp/jni/javet_v8_runtime.cpp
+++ b/cpp/jni/javet_v8_runtime.cpp
@@ -370,7 +370,7 @@ namespace Javet {
             // nodeIsolateData->set_is_building_snapshot(createSnapshotEnabled);
             node::crypto::InitCryptoOnce(v8Isolate);
         }
-        v8Isolate->SetModifyCodeGenerationFromStringsCallback(nullptr);
+        //v8Isolate->SetModifyCodeGenerationFromStringsCallback(nullptr);
 #else
         if (createSnapshotEnabled) {
             v8Isolate = v8::Isolate::Allocate();

--- a/src/main/java/com/caoccao/javet/interop/loader/JavetLibLoader.java
+++ b/src/main/java/com/caoccao/javet/interop/loader/JavetLibLoader.java
@@ -21,6 +21,7 @@ import com.caoccao.javet.exceptions.JavetError;
 import com.caoccao.javet.exceptions.JavetException;
 import com.caoccao.javet.interfaces.IJavetLogger;
 import com.caoccao.javet.utils.*;
+import io.github.pixee.security.SystemCommand;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -134,7 +135,7 @@ public final class JavetLibLoader {
                     }
                     if (JavetOSUtils.IS_LINUX || JavetOSUtils.IS_MACOS || JavetOSUtils.IS_ANDROID) {
                         try {
-                            Runtime.getRuntime().exec(new String[]{CHMOD, XRR, libFile.getAbsolutePath()}).waitFor();
+                            SystemCommand.runCommand(Runtime.getRuntime(), new String[]{CHMOD, XRR, libFile.getAbsolutePath()}).waitFor();
                         } catch (Throwable ignored) {
                         }
                     }


### PR DESCRIPTION
allowCodeGenerationFromStrings 里设置回调 解决全局eval 开启关闭问题 并且开启eval 不影响vm 里正常使用