### PR TITLE
Return stack from scripting error in JavetExecutionException.parameters

### DIFF
--- a/src/main/java/com/caoccao/javet/exceptions/BaseJavetScriptingException.java
+++ b/src/main/java/com/caoccao/javet/exceptions/BaseJavetScriptingException.java
@@ -53,7 +53,8 @@ public abstract class BaseJavetScriptingException extends JavetException {
                         JavetError.PARAMETER_START_COLUMN, scriptingError.getStartColumn(),
                         JavetError.PARAMETER_END_COLUMN, scriptingError.getEndColumn(),
                         JavetError.PARAMETER_START_POSITION, scriptingError.getStartPosition(),
-                        JavetError.PARAMETER_END_POSITION, scriptingError.getEndPosition()),
+                        JavetError.PARAMETER_END_POSITION, scriptingError.getEndPosition(),
+                        JavetError.PARAMETER_STACK, scriptingError.getStack()),
                 cause);
         this.scriptingError = scriptingError;
     }

--- a/src/main/java/com/caoccao/javet/exceptions/JavetError.java
+++ b/src/main/java/com/caoccao/javet/exceptions/JavetError.java
@@ -190,6 +190,12 @@ public class JavetError {
      */
     public static final String PARAMETER_START_POSITION = "startPosition";
     /**
+     * The constant PARAMETER_STACK.
+     *
+     * @since 4.1.5
+     */
+    public static final String PARAMETER_STACK = "stack";
+    /**
      * The constant PARAMETER_SYMBOL.
      *
      * @since 0.8.5

--- a/src/main/java/com/caoccao/javet/utils/SimpleMap.java
+++ b/src/main/java/com/caoccao/javet/utils/SimpleMap.java
@@ -283,4 +283,54 @@ public final class SimpleMap {
         map.put(k8, v8);
         return map;
     }
+
+    /**
+     * Of map.
+     *
+     * @param <K> the type parameter
+     * @param <V> the type parameter
+     * @param k1  the k1
+     * @param v1  the v1
+     * @param k2  the k2
+     * @param v2  the v2
+     * @param k3  the k3
+     * @param v3  the v3
+     * @param k4  the k4
+     * @param v4  the v4
+     * @param k5  the k5
+     * @param v5  the v5
+     * @param k6  the k6
+     * @param v6  the v6
+     * @param k7  the k7
+     * @param v7  the v7
+     * @param k8  the k8
+     * @param v8  the v8
+     * @param k9  the k9
+     * @param v9  the v9
+     * @return the map
+     * @since 4.1.5
+     */
+    public static <K, V> Map<K, V> of(
+            K k1, V v1,
+            K k2, V v2,
+            K k3, V v3,
+            K k4, V v4,
+            K k5, V v5,
+            K k6, V v6,
+            K k7, V v7,
+            K k8, V v8,
+            K k9, V v9
+    ) {
+        HashMap<K, V> map = new HashMap<K, V>();
+        map.put(k1, v1);
+        map.put(k2, v2);
+        map.put(k3, v3);
+        map.put(k4, v4);
+        map.put(k5, v5);
+        map.put(k6, v6);
+        map.put(k7, v7);
+        map.put(k8, v8);
+        map.put(k9, v9);
+        return map;
+    }
 }


### PR DESCRIPTION
This makes the stack of scripting errors accessible in `JavetExcecutionException`, which is needed because currently there is no way to get this information other than including it in the error message by wrapping all code executed in V8 in:

```javascript
try {
  // ...
} catch (e) {
  throw new Error(e.stack);
}
```