### PR TITLE
Adding option to create pool with snapshot

### DIFF
--- a/src/main/java/com/caoccao/javet/interop/engine/JavetEngineConfig.java
+++ b/src/main/java/com/caoccao/javet/interop/engine/JavetEngineConfig.java
@@ -121,6 +121,7 @@ public final class JavetEngineConfig {
     private int waitForEngineLogIntervalMillis;
     private int waitForEngineMaxRetryCount;
     private int[] waitForEngineSleepIntervalMillis;
+    private byte[] snapshotBlob;
 
     /**
      * Instantiates a new Javet engine config.
@@ -179,6 +180,14 @@ public final class JavetEngineConfig {
     public String getGlobalName() {
         return globalName;
     }
+
+    /**
+     * Gets the snapshot blob
+     *
+     * @return the snapshot blob
+     * @since 5.0.5
+     */
+    public byte[] getSnapshotBlob() { return snapshotBlob; }
 
     /**
      * Gets JS runtime type.
@@ -392,6 +401,18 @@ public final class JavetEngineConfig {
     @SuppressWarnings("UnusedReturnValue")
     public JavetEngineConfig setGlobalName(String globalName) {
         this.globalName = globalName;
+        return this;
+    }
+
+    /**
+     * Sets the snapshot blob
+     *
+     * @param snapshotBlob the snapshot blob
+     * @return the self
+     * @since 5.0.5
+     */
+    public JavetEngineConfig setSnapshotBlob(byte[] snapshotBlob) {
+        this.snapshotBlob = snapshotBlob;
         return this;
     }
 

--- a/src/main/java/com/caoccao/javet/interop/engine/JavetEngineConfig.java
+++ b/src/main/java/com/caoccao/javet/interop/engine/JavetEngineConfig.java
@@ -136,6 +136,7 @@ public final class JavetEngineConfig {
         setDefaultEngineGuardTimeoutMillis(V8Guard.DEFAULT_TIMEOUT_MILLIS);
         setGCBeforeEngineClose(false);
         setJSRuntimeType(DEFAULT_JS_RUNTIME_TYPE);
+        setSnapshotBlob(null);
         poolSizeFrozen = false;
         final int cpuCount = JavetOSUtils.getCPUCount();
         setPoolMinSize(Math.max(DEFAULT_POOL_MIN_SIZE, cpuCount >> 1));

--- a/src/main/java/com/caoccao/javet/interop/engine/JavetEnginePool.java
+++ b/src/main/java/com/caoccao/javet/interop/engine/JavetEnginePool.java
@@ -119,46 +119,22 @@ public class JavetEnginePool<R extends V8Runtime> implements IJavetEnginePool<R>
     protected Semaphore semaphore;
 
     /**
-     * The snapshot blob.
-     *
-     * @since 5.0.4
-     */
-    protected byte[] snapshotBlob;
-
-    /**
      * Instantiates a new Javet engine pool.
      *
      * @since 0.7.0
      */
     public JavetEnginePool() {
-        this(new JavetEngineConfig(), null);
+        this(new JavetEngineConfig());
     }
 
     /**
      * Instantiates a new Javet engine pool.
      *
      * @param config the config
-     * @since 5.0.4
-     */
-    public JavetEnginePool(JavetEngineConfig config) { this(config, null); }
-
-    /**
-     * Instantiates a new Javet engine pool with a snapshot blob.
-     *
-     * @param snapshotBlob the snapshot blob
-     * @since 5.0.4
-     */
-    public JavetEnginePool(byte[] snapshotBlob) { this(new JavetEngineConfig(), snapshotBlob); }
-
-    /**
-     * Instantiates a new Javet engine pool.
-     *
-     * @param config the config
-     * @param snapshotBlob the snapshot blob
      * @since 0.7.0
      */
     @SuppressWarnings("unchecked")
-    public JavetEnginePool(JavetEngineConfig config, byte[] snapshotBlob) {
+    public JavetEnginePool(JavetEngineConfig config) {
         this.config = Objects.requireNonNull(config).freezePoolSize();
         idleEngineIndexList = new ConcurrentLinkedQueue<>();
         releasedEngineIndexList = new ConcurrentLinkedQueue<>();
@@ -169,7 +145,6 @@ public class JavetEnginePool<R extends V8Runtime> implements IJavetEnginePool<R>
         quitting = false;
         random = new Random();
         semaphore = null;
-        this.snapshotBlob = snapshotBlob;
         startDaemon();
     }
 
@@ -192,8 +167,8 @@ public class JavetEnginePool<R extends V8Runtime> implements IJavetEnginePool<R>
             V8RuntimeOptions v8RuntimeOptions = (V8RuntimeOptions) runtimeOptions;
             v8RuntimeOptions.setGlobalName(config.getGlobalName());
         }
-        if (snapshotBlob != null) {
-            runtimeOptions.setSnapshotBlob(snapshotBlob);
+        if (config.getSnapshotBlob() != null) {
+            runtimeOptions.setSnapshotBlob(config.getSnapshotBlob());
         }
         @SuppressWarnings("ConstantConditions")
         R v8Runtime = V8Host.getInstance(jsRuntimeType).createV8Runtime(true, runtimeOptions);

--- a/src/main/java/com/caoccao/javet/interop/engine/JavetEnginePool.java
+++ b/src/main/java/com/caoccao/javet/interop/engine/JavetEnginePool.java
@@ -166,9 +166,9 @@ public class JavetEnginePool<R extends V8Runtime> implements IJavetEnginePool<R>
         if (runtimeOptions instanceof V8RuntimeOptions) {
             V8RuntimeOptions v8RuntimeOptions = (V8RuntimeOptions) runtimeOptions;
             v8RuntimeOptions.setGlobalName(config.getGlobalName());
-        }
-        if (config.getSnapshotBlob() != null) {
-            runtimeOptions.setSnapshotBlob(config.getSnapshotBlob());
+            if (config.getSnapshotBlob() != null) {
+                v8RuntimeOptions.setSnapshotBlob(config.getSnapshotBlob());
+            }
         }
         @SuppressWarnings("ConstantConditions")
         R v8Runtime = V8Host.getInstance(jsRuntimeType).createV8Runtime(true, runtimeOptions);

--- a/src/main/java/com/caoccao/javet/interop/engine/JavetEnginePool.java
+++ b/src/main/java/com/caoccao/javet/interop/engine/JavetEnginePool.java
@@ -119,22 +119,46 @@ public class JavetEnginePool<R extends V8Runtime> implements IJavetEnginePool<R>
     protected Semaphore semaphore;
 
     /**
+     * The snapshot blob.
+     *
+     * @since 5.0.4
+     */
+    protected byte[] snapshotBlob;
+
+    /**
      * Instantiates a new Javet engine pool.
      *
      * @since 0.7.0
      */
     public JavetEnginePool() {
-        this(new JavetEngineConfig());
+        this(new JavetEngineConfig(), null);
     }
 
     /**
      * Instantiates a new Javet engine pool.
      *
      * @param config the config
+     * @since 5.0.4
+     */
+    public JavetEnginePool(JavetEngineConfig config) { this(config, null); }
+
+    /**
+     * Instantiates a new Javet engine pool with a snapshot blob.
+     *
+     * @param snapshotBlob the snapshot blob
+     * @since 5.0.4
+     */
+    public JavetEnginePool(byte[] snapshotBlob) { this(new JavetEngineConfig(), snapshotBlob); }
+
+    /**
+     * Instantiates a new Javet engine pool.
+     *
+     * @param config the config
+     * @param snapshotBlob the snapshot blob
      * @since 0.7.0
      */
     @SuppressWarnings("unchecked")
-    public JavetEnginePool(JavetEngineConfig config) {
+    public JavetEnginePool(JavetEngineConfig config, byte[] snapshotBlob) {
         this.config = Objects.requireNonNull(config).freezePoolSize();
         idleEngineIndexList = new ConcurrentLinkedQueue<>();
         releasedEngineIndexList = new ConcurrentLinkedQueue<>();
@@ -145,6 +169,7 @@ public class JavetEnginePool<R extends V8Runtime> implements IJavetEnginePool<R>
         quitting = false;
         random = new Random();
         semaphore = null;
+        this.snapshotBlob = snapshotBlob;
         startDaemon();
     }
 
@@ -166,6 +191,9 @@ public class JavetEnginePool<R extends V8Runtime> implements IJavetEnginePool<R>
         if (runtimeOptions instanceof V8RuntimeOptions) {
             V8RuntimeOptions v8RuntimeOptions = (V8RuntimeOptions) runtimeOptions;
             v8RuntimeOptions.setGlobalName(config.getGlobalName());
+        }
+        if (snapshotBlob != null) {
+            runtimeOptions.setSnapshotBlob(snapshotBlob);
         }
         @SuppressWarnings("ConstantConditions")
         R v8Runtime = V8Host.getInstance(jsRuntimeType).createV8Runtime(true, runtimeOptions);


### PR DESCRIPTION
Added an option to initialize an engine pool with a snapshot blob.

I have a js script with several functions which I need in every engine instance from the pool.
I can't really refactor the script to be a module and from my understanding modules are bound to a single runtime, so I'd need to compile them again anyway.


		String globalScriptString = "function testFunction() { return 'Test'; }";

		V8RuntimeOptions options = new V8RuntimeOptions();
		options.setCreateSnapshotEnabled(true);
		try (V8Runtime runtime = V8Host.getV8Instance().createV8Runtime(options)) {
			runtime.getExecutor(globalScriptString).executeVoid();
			scriptSnapshot = runtime.createSnapshot();
		} catch (JavetException e1) {
			e1.printStackTrace();
		}
		
		
		try (IJavetEnginePool<V8Runtime> javetEnginePool = new JavetEnginePool<>(scriptSnapshot)) {
		    try (IJavetEngine<V8Runtime> javetEngine = javetEnginePool.getEngine()) {
		        V8Runtime v8Runtime = javetEngine.getV8Runtime();
		        //This will print 'Test' instead of throwing undefined
		        v8Runtime.getExecutor("console.log(testFunction());").executeVoid();
		    }
		}